### PR TITLE
fixing npm-publish workflow.

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -46,6 +46,8 @@ jobs:
           node-version: 16
       - run: yarn install --frozen-lockfile
       - run: yarn deploy-storybook
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
   publish-npm:
     needs: build


### PR DESCRIPTION
## Fixes #65 

## Changes
- Add github token to github-pages deployment
- Change npm token for publishing package