### PR TITLE
Remove duplicate web component definition

### DIFF
--- a/src/components/molecules/FormCheckGroup/FormCheckGroup.js
+++ b/src/components/molecules/FormCheckGroup/FormCheckGroup.js
@@ -1,4 +1,4 @@
-const template = document.createElement('template');
+const template = document.createElement("template");
 
 template.innerHTML = `
 <slot></slot>
@@ -15,23 +15,22 @@ const KEYCODE = {
 };
 
 export default class FormCheckGroup extends HTMLElement {
-
   constructor() {
     // Always call super first in constructor
     super();
     // Create a shadow root
     // Create a shadow root
-    const shadow = this.attachShadow({ mode: 'open' });
+    const shadow = this.attachShadow({ mode: "open" });
     shadow.appendChild(template.content.cloneNode(true));
   }
 
   connectedCallback() {
     // setting up styles
-    if (!this.hasAttribute('role')) {
-      if(this.getAttribute('data-type') == 'radio'){
-        this.setAttribute('role', 'radiogroup');
-      }else{
-        this.setAttribute('role', 'group');
+    if (!this.hasAttribute("role")) {
+      if (this.getAttribute("data-type") == "radio") {
+        this.setAttribute("role", "radiogroup");
+      } else {
+        this.setAttribute("role", "group");
       }
     }
     let firstFormCheck = this.checkedFormCheck;
@@ -39,16 +38,16 @@ export default class FormCheckGroup extends HTMLElement {
       this._uncheckAll();
       this._checkNode(firstFormCheck);
     } else {
-      this.querySelector('cod-form-check').setAttribute('tabindex', 0);
+      this.querySelector("cod-form-check").setAttribute("tabindex", 0);
     }
 
-    this.addEventListener('keydown', this._onKeyDown);
-    this.addEventListener('click', this._onClick);
+    this.addEventListener("keydown", this._onKeyDown);
+    this.addEventListener("click", this._onClick);
   }
 
   disconnectedCallback() {
-    this.removeEventListener('keydown', this._onKeyDown);
-    this.removeEventListener('click', this._onClick);
+    this.removeEventListener("keydown", this._onKeyDown);
+    this.removeEventListener("click", this._onClick);
   }
 
   _onKeyDown(e) {
@@ -77,7 +76,7 @@ export default class FormCheckGroup extends HTMLElement {
 
       case KEYCODE.SPACE:
         e.preventDefault();
-        if (e.target.tagName.toLowerCase() === 'cod-form-check') {
+        if (e.target.tagName.toLowerCase() === "cod-form-check") {
           this._setChecked(e.target);
         }
         break;
@@ -92,17 +91,20 @@ export default class FormCheckGroup extends HTMLElement {
   }
 
   get firstFormCheck() {
-    return this.querySelector('cod-form-check:first-of-type');
+    return this.querySelector("cod-form-check:first-of-type");
   }
 
   get lastFormCheck() {
-    return this.querySelector('cod-form-check:last-of-type');
+    return this.querySelector("cod-form-check:last-of-type");
   }
 
   _prevFormCheck(node) {
     let prev = node.previousElementSibling;
     while (prev) {
-      if (prev.getAttribute('data-type') === 'radio' || prev.getAttribute('data-type') === 'checkbox') {
+      if (
+        prev.getAttribute("data-type") === "radio" ||
+        prev.getAttribute("data-type") === "checkbox"
+      ) {
         return prev;
       }
       prev = prev.previousElementSibling;
@@ -113,7 +115,10 @@ export default class FormCheckGroup extends HTMLElement {
   _nextFormCheck(node) {
     let next = node.nextElementSibling;
     while (next) {
-      if (next.getAttribute('data-type') === 'radio' || prev.getAttribute('data-type') === 'checkbox') {
+      if (
+        next.getAttribute("data-type") === "radio" ||
+        prev.getAttribute("data-type") === "checkbox"
+      ) {
         return next;
       }
       next = next.nextElementSibling;
@@ -146,44 +151,44 @@ export default class FormCheckGroup extends HTMLElement {
   }
 
   _uncheckAll() {
-    const formCheck = this.querySelectorAll('cod-form-check');
+    const formCheck = this.querySelectorAll("cod-form-check");
     for (let i = 0; i < formCheck.length; i++) {
       let btn = formCheck[i];
-      btn.setAttribute('data-checked', 'false');
-      btn.setAttribute('data-required', 'false');
+      btn.setAttribute("data-checked", "false");
+      btn.setAttribute("data-required", "false");
       btn.tabIndex = -1;
     }
   }
 
-  _validateRequired(){
-    const formCheck = this.querySelectorAll('cod-form-check');
+  _validateRequired() {
+    const formCheck = this.querySelectorAll("cod-form-check");
     let isValid = false;
     for (let i = 0; i < formCheck.length; i++) {
       let checkbox = formCheck[i];
-      (checkbox.formCheck.checked) ? isValid = true : 0;
+      checkbox.formCheck.checked ? (isValid = true) : 0;
     }
-    (isValid) ? this._unRequiredAll() : this._requiredAll();
+    isValid ? this._unRequiredAll() : this._requiredAll();
   }
 
-  _requiredAll(){
-    const formCheck = this.querySelectorAll('cod-form-check');
+  _requiredAll() {
+    const formCheck = this.querySelectorAll("cod-form-check");
     for (let i = 0; i < formCheck.length; i++) {
       let btn = formCheck[i];
-      btn.setAttribute('data-required', 'true');
+      btn.setAttribute("data-required", "true");
     }
   }
 
-  _unRequiredAll(){
-    const formCheck = this.querySelectorAll('cod-form-check');
+  _unRequiredAll() {
+    const formCheck = this.querySelectorAll("cod-form-check");
     for (let i = 0; i < formCheck.length; i++) {
       let btn = formCheck[i];
-      btn.setAttribute('data-required', 'false');
+      btn.setAttribute("data-required", "false");
     }
   }
 
   _checkNode(node) {
-    node.setAttribute('data-checked', 'true');
-    node.setAttribute('data-required', 'true');
+    node.setAttribute("data-checked", "true");
+    node.setAttribute("data-required", "true");
     node.tabIndex = 0;
   }
 
@@ -192,13 +197,13 @@ export default class FormCheckGroup extends HTMLElement {
   }
 
   _onClick(e) {
-    if (e.target.getAttribute('data-type') === 'radio') {
+    if (e.target.getAttribute("data-type") === "radio") {
       this._setChecked(e.target);
     }
-    if (e.target.getAttribute('data-type') === 'checkbox') {
-      if(this.getAttribute('data-required') == 'true'){
+    if (e.target.getAttribute("data-type") === "checkbox") {
+      if (this.getAttribute("data-required") == "true") {
         this._validateRequired(e.target);
       }
     }
   }
-};
+}

--- a/src/components/molecules/FormCheckGroup/formcheckgroup.js
+++ b/src/components/molecules/FormCheckGroup/formcheckgroup.js
@@ -1,2 +1,0 @@
-import FormCheckGroup from '../components/atoms/FormCheckGroup';
-customElements.define('cod-form-check-group', FormCheckGroup);


### PR DESCRIPTION
Context
---

There were two files (`formcheckgroup.js` and `cod-form-check-group.js`) that were defining the `cod-form-check-group` web component. The former causes file name conflicts on non-case sensitive OSes (e.g. OSX). 

This PR
---

Delete one of the duplicate web component definitions: `formcheckgroup.js`.

Testing
---

Inspect form check group in storybook manually. Looks good!
<img width="1502" alt="Screenshot 2023-09-11 at 9 33 51 AM" src="https://github.com/jedgar1mx/COD-Design-System/assets/143553259/5e6804fd-0995-4398-95ce-db98b959357c">

Run storybook test suite.

```
$ yarn test-storybook
 PASS   browser: chromium  src/stories/offcanvas.stories.js
 PASS   browser: chromium  src/stories/accordion.stories.js
 PASS   browser: chromium  src/stories/modal.stories.js
 PASS   browser: chromium  src/stories/listgroup.stories.js
 PASS   browser: chromium  src/stories/card.stories.js
 PASS   browser: chromium  src/stories/carousel.stories.js
 PASS   browser: chromium  src/stories/formcheck.stories.js
 PASS   browser: chromium  src/stories/pagination.stories.js
 PASS   browser: chromium  src/stories/dropdown.stories.js
 PASS   browser: chromium  src/stories/navbar.stories.js
 PASS   browser: chromium  src/stories/formselect.stories.js
 PASS   browser: chromium  src/stories/buttongroup.stories.js
 PASS   browser: chromium  src/stories/nav.stories.js
 PASS   browser: chromium  src/stories/button.stories.js
 PASS   browser: chromium  src/stories/breadcrumb.stories.js
 PASS   browser: chromium  src/stories/spinner.stories.js
 PASS   browser: chromium  src/stories/badge.stories.js
 PASS   browser: chromium  src/stories/image.stories.js
 PASS   browser: chromium  src/stories/formcontrol.stories.js
 PASS   browser: chromium  src/stories/range.stories.js
 PASS   browser: chromium  src/stories/formlabel.stories.js
 PASS   browser: chromium  src/stories/alert.stories.js
 PASS   browser: chromium  src/stories/progress.stories.js
 PASS   browser: chromium  src/stories/icon.stories.js
 PASS   browser: chromium  src/stories/container.stories.js
 PASS   browser: chromium  src/stories/loader.stories.js
 PASS   browser: chromium  src/stories/geocoder.stories.js
 PASS   browser: chromium  src/stories/formcheckgroup.stories.js
 PASS   browser: chromium  src/stories/form.stories.js
 PASS   browser: chromium  src/stories/table.stories.js (6.567 s)

Test Suites: 30 passed, 30 total
Tests:       154 passed, 154 total
Snapshots:   0 total
Time:        8.148 s
Ran all test suites.
```