### PR TITLE
Fix card component lints & bug

### DIFF
--- a/src/components/organisms/Card/Card.js
+++ b/src/components/organisms/Card/Card.js
@@ -17,102 +17,65 @@ export default class Card extends HTMLElement {
     shadow.appendChild(template.content.cloneNode(true));
     this.card = document.createElement('div');
 
-    // TODO: See CityOfDetroit/detroitmi#1099
-    // eslint-disable-next-line no-unused-vars
-    shadow.addEventListener('slotchange', (e) => {
-      // TODO: See CityOfDetroit/detroitmi#1099
-      // eslint-disable-next-line prefer-const
-      let tempElements = Array.from(this.children);
+    shadow.addEventListener('slotchange', () => {
+      const tempElements = Array.from(this.children);
       tempElements.forEach((node) => {
         switch (node.tagName) {
-          case 'COD-CARD-HEADER':
-            // TODO: See CityOfDetroit/detroitmi#1099
-            // eslint-disable-next-line no-case-declarations, prefer-const
-            let tempHeader = document.createElement('div');
-            // TODO: See CityOfDetroit/detroitmi#1099
-            // eslint-disable-next-line no-case-declarations, prefer-const
-            let tempHeaderClasses = ['card-header'];
-            // TODO: See CityOfDetroit/detroitmi#1099
-            // eslint-disable-next-line eqeqeq
-            node.getAttribute('data-extra-classes') != undefined &&
-            // TODO: See CityOfDetroit/detroitmi#1099
-            // eslint-disable-next-line eqeqeq
-            node.getAttribute('data-extra-classes') != null
+          case 'COD-CARD-HEADER': {
+            const tempHeader = document.createElement('div');
+            const tempHeaderClasses = ['card-header'];
+            node.getAttribute('data-extra-classes') !== null &&
+            node.getAttribute('data-extra-classes') !== null
               ? tempHeaderClasses.push(node.getAttribute('data-extra-classes'))
               : 0;
             tempHeader.className = tempHeaderClasses.join(' ');
             tempHeader.appendChild(node);
             this.card.appendChild(tempHeader);
             break;
-
-          case 'COD-CARD-BODY':
-            // TODO: See CityOfDetroit/detroitmi#1099
-            // eslint-disable-next-line no-case-declarations, prefer-const
-            let tempBody = document.createElement('div');
-            // TODO: See CityOfDetroit/detroitmi#1099
-            // eslint-disable-next-line no-case-declarations, prefer-const
-            let tempBodyClasses = ['card-body'];
-            // TODO: See CityOfDetroit/detroitmi#1099
-            // eslint-disable-next-line eqeqeq
-            node.getAttribute('data-extra-classes') != undefined &&
-            // TODO: See CityOfDetroit/detroitmi#1099
-            // eslint-disable-next-line eqeqeq
-            node.getAttribute('data-extra-classes') != null
-              ? tempHeaderClasses.push(node.getAttribute('data-extra-classes'))
+          }
+          case 'COD-CARD-BODY': {
+            const tempBody = document.createElement('div');
+            const tempBodyClasses = ['card-body'];
+            node.getAttribute('data-extra-classes') !== null &&
+            node.getAttribute('data-extra-classes') !== null
+              ? tempBodyClasses.push(node.getAttribute('data-extra-classes'))
               : 0;
             tempBody.className = tempBodyClasses.join(' ');
             tempBody.appendChild(node);
             this.card.appendChild(tempBody);
             break;
-
-          case 'COD-CARD-FOOTER':
-            // TODO: See CityOfDetroit/detroitmi#1099
-            // eslint-disable-next-line no-case-declarations, prefer-const
-            let tempFooter = document.createElement('div');
-            // TODO: See CityOfDetroit/detroitmi#1099
-            // eslint-disable-next-line no-case-declarations, prefer-const
-            let tempFooterClasses = ['card-footer'];
-            // TODO: See CityOfDetroit/detroitmi#1099
-            // eslint-disable-next-line eqeqeq
-            node.getAttribute('data-extra-classes') != undefined &&
-            // TODO: See CityOfDetroit/detroitmi#1099
-            // eslint-disable-next-line eqeqeq
-            node.getAttribute('data-extra-classes') != null
+          }
+          case 'COD-CARD-FOOTER': {
+            const tempFooter = document.createElement('div');
+            const tempFooterClasses = ['card-footer'];
+            node.getAttribute('data-extra-classes') !== null &&
+            node.getAttribute('data-extra-classes') !== null
               ? tempFooterClasses.push(node.getAttribute('data-extra-classes'))
               : 0;
             tempFooter.className = tempFooterClasses.join(' ');
             tempFooter.appendChild(node);
             this.card.appendChild(tempFooter);
             break;
-
-          case 'COD-CARD-OVERLAY':
-            // TODO: See CityOfDetroit/detroitmi#1099
-            // eslint-disable-next-line no-case-declarations, prefer-const
-            let tempOverlay = document.createElement('div');
-            // TODO: See CityOfDetroit/detroitmi#1099
-            // eslint-disable-next-line no-case-declarations, prefer-const
-            let tempOverlayClasses = ['card-img-overlay'];
-            // TODO: See CityOfDetroit/detroitmi#1099
-            // eslint-disable-next-line eqeqeq
-            node.getAttribute('data-extra-classes') != undefined &&
-            // TODO: See CityOfDetroit/detroitmi#1099
-            // eslint-disable-next-line eqeqeq
-            node.getAttribute('data-extra-classes') != null
+          }
+          case 'COD-CARD-OVERLAY': {
+            const tempOverlay = document.createElement('div');
+            const tempOverlayClasses = ['card-img-overlay'];
+            node.getAttribute('data-extra-classes') !== null &&
+            node.getAttribute('data-extra-classes') !== null
               ? tempOverlayClasses.push(node.getAttribute('data-extra-classes'))
               : 0;
             tempOverlay.className = tempOverlayClasses.join(' ');
             tempOverlay.appendChild(node);
             this.card.appendChild(tempOverlay);
             break;
-
-          default:
-            // TODO: See CityOfDetroit/detroitmi#1099
-            // eslint-disable-next-line no-case-declarations, prefer-const
-            let nodeClasses = node.className.split(' ');
+          }
+          default: {
+            const nodeClasses = node.className.split(' ');
             nodeClasses.includes('no-wc')
               ? node.remove()
               : this.card.appendChild(node);
             break;
+          }
         }
       });
     });
@@ -131,29 +94,13 @@ export default class Card extends HTMLElement {
 
   connectedCallback() {
     // Card attributes
-    // TODO: See CityOfDetroit/detroitmi#1099
-    // eslint-disable-next-line prefer-const
-    let width = this.getAttribute('data-width');
-    // TODO: See CityOfDetroit/detroitmi#1099
-    // eslint-disable-next-line prefer-const
-    let id = this.getAttribute('data-id');
-    // TODO: See CityOfDetroit/detroitmi#1099
-    // eslint-disable-next-line prefer-const
-    let extraClasses = this.getAttribute('data-extra-classes');
-    // TODO: See CityOfDetroit/detroitmi#1099
-    // eslint-disable-next-line prefer-const
-    let cardClasses = ['card'];
-    // TODO: See CityOfDetroit/detroitmi#1099
-    // eslint-disable-next-line eqeqeq
-    extraClasses != undefined && extraClasses != null
-      ? cardClasses.push(extraClasses)
-      : 0;
-    // TODO: See CityOfDetroit/detroitmi#1099
-    // eslint-disable-next-line eqeqeq
-    width != undefined && width != null ? (this.card.style.width = width) : 0;
-    // TODO: See CityOfDetroit/detroitmi#1099
-    // eslint-disable-next-line eqeqeq
-    id != undefined && id != null ? (this.card.id = id) : 0;
+    const width = this.getAttribute('data-width');
+    const id = this.getAttribute('data-id');
+    const extraClasses = this.getAttribute('data-extra-classes');
+    const cardClasses = ['card'];
+    extraClasses !== null ? cardClasses.push(extraClasses) : 0;
+    width !== null ? (this.card.style.width = width) : 0;
+    id !== null ? (this.card.id = id) : 0;
     this.card.className = cardClasses.join(' ');
     if (!this.shadowRoot.querySelector('div')) {
       this.shadowRoot.appendChild(this.card);


### PR DESCRIPTION
Note: Part of CityOfDetroit/detroitmi#1099

## This PR
---

* Fixes lint errors (not using strict equality, lack of lexical scope in switch statements, and using let instead of const)
* Fixes a bug identified due to linting (yay) - see comment on code for info

## Testing
---

Render storybook looks good for card component (including functionality):

<img width="1497" alt="Screenshot 2023-10-03 at 10 55 04 AM" src="https://github.com/CityOfDetroit/COD-Design-System/assets/143553259/efc4f346-e4fa-424b-9ab0-81f6be1086ba">

Running storybook tests pass:
```
$ yarn test-storybook
 PASS   browser: chromium  src/stories/offcanvas.stories.js
 PASS   browser: chromium  src/stories/modal.stories.js
 PASS   browser: chromium  src/stories/accordion.stories.js
 PASS   browser: chromium  src/stories/listgroup.stories.js
 PASS   browser: chromium  src/stories/card.stories.js
 PASS   browser: chromium  src/stories/carousel.stories.js
 PASS   browser: chromium  src/stories/dropdown.stories.js
 PASS   browser: chromium  src/stories/buttongroup.stories.js
 PASS   browser: chromium  src/stories/formcheck.stories.js
 PASS   browser: chromium  src/stories/button.stories.js
 PASS   browser: chromium  src/stories/form.stories.js
 PASS   browser: chromium  src/stories/nav.stories.js
 PASS   browser: chromium  src/stories/navbar.stories.js
 PASS   browser: chromium  src/stories/formcheckgroup.stories.js
 PASS   browser: chromium  src/stories/formselect.stories.js
 PASS   browser: chromium  src/stories/formcontrol.stories.js
 PASS   browser: chromium  src/stories/badge.stories.js
 PASS   browser: chromium  src/stories/progress.stories.js
 PASS   browser: chromium  src/stories/pagination.stories.js
 PASS   browser: chromium  src/stories/image.stories.js
 PASS   browser: chromium  src/stories/breadcrumb.stories.js
 PASS   browser: chromium  src/stories/container.stories.js
 PASS   browser: chromium  src/stories/formlabel.stories.js
 PASS   browser: chromium  src/stories/alert.stories.js
 PASS   browser: chromium  src/stories/spinner.stories.js
 PASS   browser: chromium  src/stories/loader.stories.js
 PASS   browser: chromium  src/stories/icon.stories.js
 PASS   browser: chromium  src/stories/range.stories.js
 PASS   browser: chromium  src/stories/geocoder.stories.js
 PASS   browser: chromium  src/stories/table.stories.js (7.919 s)

Test Suites: 30 passed, 30 total
Tests:       155 passed, 155 total
Snapshots:   0 total
Time:        9.836 s
Ran all test suites.
```