### PR TITLE
Prevent duplicate icons rendered

### DIFF
--- a/src/components/atoms/Icon/Icon.js
+++ b/src/components/atoms/Icon/Icon.js
@@ -2,13 +2,16 @@ export default class Icon extends HTMLElement {
   constructor() {
     // Always call super first in constructor
     super();
-    // Create a shadow root
-    // TODO: See CityOfDetroit/detroitmi#1099
-    // eslint-disable-next-line no-unused-vars
-    const shadow = this.attachShadow({ mode: 'open' });
+
+    // Create a shadow root.
+    this.attachShadow({ mode: 'open' });
   }
 
   connectedCallback() {
+    if (this.isIconConnected()) {
+      return;
+    }
+
     // Icon attributes
     // TODO: See CityOfDetroit/detroitmi#1099
     // eslint-disable-next-line prefer-const
@@ -37,6 +40,10 @@ export default class Icon extends HTMLElement {
     const iconContainer = document.createElement('span');
     iconContainer.innerHTML = this.getIcon(icon, size);
     this.shadowRoot.appendChild(iconContainer);
+  }
+
+  isIconConnected() {
+    return this.shadowRoot.querySelector('span') !== null;
   }
 
   getIcon(icon, size) {


### PR DESCRIPTION
## The Bug

The current implementation of Icon.js was not guarding against [`connectedCallback` being called multiple times](https://html.spec.whatwg.org/multipage/custom-elements.html#custom-element-conformance).

See details for when this may happen.

<details><summary>Details</summary>
<p>

The most common scenario in our UXDS would be when we're adding the `<cod-icon/>` element to another slotted custom element. This causes the `<cod-icon/>` component to be connected twice: once when attached to the slot, then again when `onslotchange` event handler attaches it to the shadowDOM of the parent component. E.g.

NOTE: In the below example, the component is actually connected three times because both `cod-card` and `cod-card-icon-container` are slotted elements.

```html
  <cod-card data-width="18em" data-extra-classes="text-center">
    <cod-card-icon-container>
      <cod-icon data-icon="house" data-size="x-large"></cod-icon>
    </cod-card-icon-container>
    <cod-card-body>
      <h5 class="card-title">Card title</h5>
      <p class="card-text">
        Some compelling text.
      </p>
    </cod-card-body>
  </cod-card>
```

This results in the following:
<img width="293" alt="Screenshot 2023-10-05 at 10 48 53 AM" src="https://github.com/CityOfDetroit/COD-Design-System/assets/143553259/0213e215-15dd-46aa-857e-fa7a581869c9">


</p>
</details> 

## Proposed Fix (This PR)

Add a guard in `connectedCallback` to check if the icon span is already attached to the shadowDom and return early if so.

## Alternatives Considered

1. We could attach the shadow root as part of the `connectedCallback` method which would recreate a shadowDOM each time the component is attached to the DOM. This is a reasonable alternative but the performance implications are unclear and `connectedCallback` can be called many times.


2. We could remove the icon element from the shadowDOM on `disconnectedCallback` lifecycle event. This type of lifecycle management might be appropriate if we were managing some state that needed to be reset, but since the icon elememnt does not change between lifecycle events, it's probably best to just let it live between events.

## Testing

* Build a story that uses the icon element nested in a couple slotted elements.
* Before this PR: observe that the icon is rendered multiple times.

<img width="293" alt="Screenshot 2023-10-05 at 10 48 53 AM" src="https://github.com/CityOfDetroit/COD-Design-System/assets/143553259/fa869069-460f-4719-a21d-e7abe1ae3c9f">

* After this PR: observe that the icon is rendered once.

<img width="295" alt="Screenshot 2023-10-05 at 10 49 07 AM" src="https://github.com/CityOfDetroit/COD-Design-System/assets/143553259/426f5a09-f7f9-462e-adc6-e609be5eb55e">

