### PR TITLE
Add chevron icons to `<cod-icon/>`

### DIFF
--- a/src/components/atoms/Icon/Icon.js
+++ b/src/components/atoms/Icon/Icon.js
@@ -41,6 +41,26 @@ export default class Icon extends HTMLElement {
 
   getIcon(icon, size) {
     switch (icon) {
+      case 'chevron-right':
+        return `
+                <svg xmlns="http://www.w3.org/2000/svg" width="${size}" height="${size}" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
+                    <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708z"/>
+                </svg>`;
+      case 'chevron-left':
+        return `
+                <svg xmlns="http://www.w3.org/2000/svg" width="${size}" height="${size}" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
+                    <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0z"/>
+                </svg>`;
+      case 'chevron-up':
+        return `
+                <svg xmlns="http://www.w3.org/2000/svg" width="${size}" height="${size}" fill="currentColor" class="bi bi-chevron-up" viewBox="0 0 16 16">
+                    <path fill-rule="evenodd" d="M7.646 4.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1-.708.708L8 5.707l-5.646 5.647a.5.5 0 0 1-.708-.708l6-6z"/>
+                </svg>`;
+      case 'chevron-down':
+        return `
+                <svg xmlns="http://www.w3.org/2000/svg" width="${size}" height="${size}" fill="currentColor" class="bi bi-chevron-down" viewBox="0 0 16 16">
+                    <path fill-rule="evenodd" d="M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z"/>
+                </svg>`;
       case 'house':
         return `
                 <svg xmlns="http://www.w3.org/2000/svg" width="${size}" height="${size}" fill="currentColor" class="bi bi-house" viewBox="0 0 16 16">

--- a/src/stories/icon.stories.js
+++ b/src/stories/icon.stories.js
@@ -6,6 +6,10 @@ export default {
     icon: {
       control: { type: 'select' },
       options: [
+        'chevron-right',
+        'chevron-left',
+        'chevron-up',
+        'chevron-down',
         'house',
         'house-fill',
         'exclamation-circle',


### PR DESCRIPTION
## This PR Closes #105 

Keeping the PR message nice and tight here. 

Adds the following icons to the `<cod-icon/>` component:
* https://icons.getbootstrap.com/icons/chevron-down/
* https://icons.getbootstrap.com/icons/chevron-up/
* https://icons.getbootstrap.com/icons/chevron-left/
* https://icons.getbootstrap.com/icons/chevron-right/

## Testing

Viewed the icons in Storybook at various sizes:

![Screenshot 2023-10-13 at 2 36 27 PM](https://github.com/CityOfDetroit/COD-Design-System/assets/143553259/64edc176-a599-468c-8261-604b1531e37a)
![Screenshot 2023-10-13 at 2 36 34 PM](https://github.com/CityOfDetroit/COD-Design-System/assets/143553259/77b194ec-d41d-4162-82ac-805f1284d7ba)
![Screenshot 2023-10-13 at 2 36 39 PM](https://github.com/CityOfDetroit/COD-Design-System/assets/143553259/f71e62d5-91a2-45bf-b3ad-1fe29bff51d8)
![Screenshot 2023-10-13 at 2 36 47 PM](https://github.com/CityOfDetroit/COD-Design-System/assets/143553259/1f5b2cff-10f8-4cf3-b685-18d42762cf24)
![Screenshot 2023-10-13 at 2 36 51 PM](https://github.com/CityOfDetroit/COD-Design-System/assets/143553259/142d6d61-1610-4d7b-850d-e071f118d23c)


