### PR TITLE
Fixing a11y plugin typo.

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -3,7 +3,7 @@ module.exports = {
   addons: [
     '@storybook/addon-links',
     '@storybook/addon-essentials',
-    '@storybook/addon-a12y',
+    '@storybook/addon-a11y',
     '@storybook/addon-coverage',
     '@storybook/addon-interactions',
     '@storybook/addon-mdx-gfm',


### PR DESCRIPTION
## Fixes #116 

## Changes
- Simple typo fix for `a11y` storybook plugin.

## Tests
<img width="873" alt="image" src="https://github.com/CityOfDetroit/COD-Design-System/assets/21081923/b600f347-db03-4092-a9c7-dedabab38a42">
