### PR TITLE
Fix dark navbar theming

### DIFF
--- a/src/components/atoms/NavbarToggle/NavbarToggle.js
+++ b/src/components/atoms/NavbarToggle/NavbarToggle.js
@@ -23,13 +23,11 @@ export default class NavbarToggle extends HTMLElement {
 
   connectedCallback() {
     // Navbar Brand attributes
-    const darkBtn = this.getAttribute('data-button-dark');
     const mode = this.getAttribute('data-mode');
     const extraClasses = this.getAttribute('data-extra-classes');
     const toggleBtn = document.createElement('button');
     const navbarToggleClasses = [''];
     if (mode === 'default') {
-      darkBtn === 'true' ? toggleBtn.setAttribute('data-bs-theme', 'dark') : 0;
       const toggleIcon = document.createElement('span');
       navbarToggleClasses.push('navbar-toggler-icon');
       toggleBtn.appendChild(toggleIcon);

--- a/src/components/organisms/Navbar/Navbar.js
+++ b/src/components/organisms/Navbar/Navbar.js
@@ -36,9 +36,6 @@ export default class Navbar extends HTMLElement {
             this.getAttribute('data-show') === 'true'
               ? node.setAttribute('data-show', true)
               : 0;
-            this.getAttribute('data-button-dark') === 'true'
-              ? node.setAttribute('data-button-dark', true)
-              : 0;
             this.navbarToggle.appendChild(node);
             this.navbarContainer.appendChild(this.navbarToggle);
             break;

--- a/src/components/organisms/Navbar/Navbar.js
+++ b/src/components/organisms/Navbar/Navbar.js
@@ -112,6 +112,10 @@ export default class Navbar extends HTMLElement {
     extraClasses ? navbarClasses.push(extraClasses) : 0;
     collapseClasses ? navbarCollapseClasses.push(collapseClasses) : 0;
     placement ? navbarClasses.push(placement) : 0;
+    const isDark = this.getAttribute('data-navbar-dark') === 'true';
+    if (isDark) {
+      navbarClasses.push(['navbar-dark']);
+    }
     if (expand) {
       expand === 'always'
         ? navbarClasses.push('navbar-expand')

--- a/src/stories/navbar.stories.js
+++ b/src/stories/navbar.stories.js
@@ -295,8 +295,7 @@ export const Color = () => html`
       data-text-classes="text-light"
     >
     </cod-navbar-brand>
-    <cod-navbar-toggle data-mode="default">
-    </cod-navbar-toggle>
+    <cod-navbar-toggle data-mode="default"> </cod-navbar-toggle>
     <cod-navbar-collapse>
       <cod-nav>
         <a class="nav-link text-light" href="#">Home</a>
@@ -318,8 +317,7 @@ export const Color = () => html`
       data-text-classes="text-light"
     >
     </cod-navbar-brand>
-    <cod-navbar-toggle data-mode="default">
-    </cod-navbar-toggle>
+    <cod-navbar-toggle data-mode="default"> </cod-navbar-toggle>
     <cod-navbar-collapse>
       <cod-nav>
         <a class="nav-link text-light" href="#">Home</a>
@@ -506,7 +504,10 @@ export const OffcanvasColor = () => html`
     >
     </cod-navbar-brand>
     <cod-offcanvas data-id="offcanvasExample" data-extra-classes="bg-dark">
-      <cod-offcanvas-header data-extra-classes="bg-dark text-light" data-button-dark="true">
+      <cod-offcanvas-header
+        data-extra-classes="bg-dark text-light"
+        data-button-dark="true"
+      >
         <h5>Offcanvas</h5>
       </cod-offcanvas-header>
       <cod-offcanvas-body data-extra-classes="bg-dark">
@@ -549,7 +550,6 @@ export const OffcanvasColor = () => html`
         </cod-nav>
       </cod-offcanvas-body>
     </cod-offcanvas>
-    <cod-navbar-toggle data-mode="default">
-    </cod-navbar-toggle>
+    <cod-navbar-toggle data-mode="default"> </cod-navbar-toggle>
   </cod-navbar>
 `;

--- a/src/stories/navbar.stories.js
+++ b/src/stories/navbar.stories.js
@@ -287,6 +287,7 @@ export const Color = () => html`
     data-container-classes="container-fluid"
     data-expand="md"
     data-extra-classes="bg-dark"
+    data-navbar-dark="true"
   >
     <cod-navbar-brand
       data-url="#"

--- a/src/stories/navbar.stories.js
+++ b/src/stories/navbar.stories.js
@@ -295,7 +295,7 @@ export const Color = () => html`
       data-text-classes="text-light"
     >
     </cod-navbar-brand>
-    <cod-navbar-toggle data-mode="default" data-button-dark="true">
+    <cod-navbar-toggle data-mode="default">
     </cod-navbar-toggle>
     <cod-navbar-collapse>
       <cod-nav>
@@ -318,7 +318,7 @@ export const Color = () => html`
       data-text-classes="text-light"
     >
     </cod-navbar-brand>
-    <cod-navbar-toggle data-mode="default" data-button-dark="true">
+    <cod-navbar-toggle data-mode="default">
     </cod-navbar-toggle>
     <cod-navbar-collapse>
       <cod-nav>
@@ -506,7 +506,7 @@ export const OffcanvasColor = () => html`
     >
     </cod-navbar-brand>
     <cod-offcanvas data-id="offcanvasExample" data-extra-classes="bg-dark">
-      <cod-offcanvas-header data-extra-classes="bg-dark text-light">
+      <cod-offcanvas-header data-extra-classes="bg-dark text-light" data-button-dark="true">
         <h5>Offcanvas</h5>
       </cod-offcanvas-header>
       <cod-offcanvas-body data-extra-classes="bg-dark">
@@ -549,7 +549,7 @@ export const OffcanvasColor = () => html`
         </cod-nav>
       </cod-offcanvas-body>
     </cod-offcanvas>
-    <cod-navbar-toggle data-mode="default" data-button-dark="true">
+    <cod-navbar-toggle data-mode="default">
     </cod-navbar-toggle>
   </cod-navbar>
 `;


### PR DESCRIPTION
# Fixes #121 

## Changes in this PR
* Remove `data-bs-theme` usage in navbar since it has no effect on the navbar as currently written
* Enable support for `navbar-dark` on navbar which correctly styles the toggle component

Bootstrap 5.3 docs indicate that the [`navbar-dark` class is deprecated](https://getbootstrap.com/docs/5.3/components/navbar/#color-schemes) in favor of dark theme (`data-bs-theme=dark`, however out-of-the-box the navbar toggle component is not controlled by `data-bs-theme=dark` and still relies on the CSS variables overridden by `navbar-dark`.

Once we properly address #114 , we can re-add support for theming and customize bootstrap so that the theme properly customizes the navbar toggle as well.

## Testing

## Before PR

https://github.com/CityOfDetroit/COD-Design-System/assets/143553259/6d3b7e42-19af-44ed-8165-b6718c593f89


https://github.com/CityOfDetroit/COD-Design-System/assets/143553259/ba5db5c5-f688-4f98-9f18-aec7c855e642

## After PR

https://github.com/CityOfDetroit/COD-Design-System/assets/143553259/fe3836ac-a8e2-4255-bd97-0781f57dd65f


https://github.com/CityOfDetroit/COD-Design-System/assets/143553259/8ceb912e-bab3-4bc9-bff5-8bc5d25a5e24
