### PR TITLE
Use BS nav classes to set offcanvas nav direction

### DIFF
--- a/src/components/atoms/OffcanvasBody/OffcanvasBody.js
+++ b/src/components/atoms/OffcanvasBody/OffcanvasBody.js
@@ -19,6 +19,9 @@ export default class OffcanvasBody extends HTMLElement {
     this.shadowRoot.addEventListener('slotchange', () => {
       const tempElements = Array.from(this.children);
       tempElements.forEach((node) => {
+        if (node.tagName === 'COD-NAV') {
+          node.setAttribute('data-offcanvas-nav', true);
+        }
         this.body.append(node);
       });
     });

--- a/src/components/atoms/OffcanvasBody/OffcanvasBody.js
+++ b/src/components/atoms/OffcanvasBody/OffcanvasBody.js
@@ -20,7 +20,7 @@ export default class OffcanvasBody extends HTMLElement {
       const tempElements = Array.from(this.children);
       tempElements.forEach((node) => {
         if (node.tagName === 'COD-NAV') {
-          node.setAttribute('data-offcanvas-nav', true);
+          node.setAttribute('data-extra-classes', 'navbar-nav');
         }
         this.body.append(node);
       });

--- a/src/components/molecules/Nav/Nav.css
+++ b/src/components/molecules/Nav/Nav.css
@@ -1,3 +1,8 @@
 .nav-item {
   font-family: var(--font-family);
 }
+
+.navbar-nav .nav-link {
+  --bs-nav-link-padding-x: 0.75em;
+  --bs-btn-padding-x: var(--bs-nav-link-padding-x);
+}

--- a/src/components/molecules/Nav/Nav.css
+++ b/src/components/molecules/Nav/Nav.css
@@ -1,3 +1,7 @@
 .nav-item {
   font-family: var(--font-family);
 }
+
+.offcanvas-nav {
+  flex-direction: column;
+}

--- a/src/components/molecules/Nav/Nav.css
+++ b/src/components/molecules/Nav/Nav.css
@@ -1,7 +1,3 @@
 .nav-item {
   font-family: var(--font-family);
 }
-
-.offcanvas-nav {
-  flex-direction: column;
-}

--- a/src/components/molecules/Nav/Nav.js
+++ b/src/components/molecules/Nav/Nav.js
@@ -53,6 +53,10 @@ export default class Nav extends HTMLElement {
     const justified = this.getAttribute('data-justified');
     const extraClasses = this.getAttribute('data-extra-classes');
     const navClasses = ['nav'];
+    const isOffcanvasNav = this.getAttribute('data-offcanvas-nav') === 'true';
+    if (isOffcanvasNav) {
+      navClasses.push('offcanvas-nav');
+    }
     vertical === 'true' ? navClasses.push('flex-column') : 0;
     tabs === 'true' ? navClasses.push('nav-tabs') : 0;
     pills === 'true' ? navClasses.push('nav-pills') : 0;

--- a/src/components/molecules/Nav/Nav.js
+++ b/src/components/molecules/Nav/Nav.js
@@ -53,10 +53,6 @@ export default class Nav extends HTMLElement {
     const justified = this.getAttribute('data-justified');
     const extraClasses = this.getAttribute('data-extra-classes');
     const navClasses = ['nav'];
-    const isOffcanvasNav = this.getAttribute('data-offcanvas-nav') === 'true';
-    if (isOffcanvasNav) {
-      navClasses.push('offcanvas-nav');
-    }
     vertical === 'true' ? navClasses.push('flex-column') : 0;
     tabs === 'true' ? navClasses.push('nav-tabs') : 0;
     pills === 'true' ? navClasses.push('nav-pills') : 0;

--- a/src/stories/navbar.stories.js
+++ b/src/stories/navbar.stories.js
@@ -449,7 +449,7 @@ export const Offcanvas = () => html`
         <h5>Offcanvas</h5>
       </cod-offcanvas-header>
       <cod-offcanvas-body>
-        <cod-nav data-vertical="true">
+        <cod-nav>
           <a class="nav-link active" aria-current="page" href="#">Home</a>
           <a class="nav-link" href="#">Link</a>
           <cod-dropdown data-split="false">
@@ -511,7 +511,7 @@ export const OffcanvasColor = () => html`
         <h5>Offcanvas</h5>
       </cod-offcanvas-header>
       <cod-offcanvas-body data-extra-classes="bg-dark">
-        <cod-nav data-vertical="true" data-extra-classes="text-light">
+        <cod-nav data-extra-classes="text-light">
           <a class="nav-link active text-light" aria-current="page" href="#"
             >Home</a
           >


### PR DESCRIPTION
## Part of #122 

## This PR

* Remove the necessity to use `flex-column` on navbar when inside offcanvas
* Use `navbar-nav` (which comes with column flex direction by default) to set column flex direction 

We need this change for the following reason:

For #122 we want to support an expandable navbar with nav hidden in an offcanvas element on small screens. E.g. [this demo](https://stackblitz.com/edit/gtrwoz-jghnee?file=index.html). However this is not possible when using `data-vertical` and `flex-column` because bootstrap's `flex-column` utility uses `!important` which would override any flex direction we set on responsive breakpoints.

## Testing

Confirm that vertical nav option still works when explicitly set by `data-vertical`.


https://github.com/CityOfDetroit/COD-Design-System/assets/143553259/fb720d2a-c3c2-4d46-aba4-70ef6650b248

Confirm that offcanvas navigation links are column flex direction even when `data-vertical` is not set.


https://github.com/CityOfDetroit/COD-Design-System/assets/143553259/0255fb44-1eec-4f39-a870-1e44f2dacd09

