### PR TITLE
Leverage slots in accordion header

### DIFF
--- a/src/components/atoms/AccordionHeader/AccordionHeader.css
+++ b/src/components/atoms/AccordionHeader/AccordionHeader.css
@@ -1,6 +1,4 @@
 .li-num-box {
-  /* TODO: Dynamically update list numbers to match accordion
-    header text styles */
   width: 3rem;
   height: 3rem;
   display: flex;

--- a/src/components/atoms/AccordionHeader/AccordionHeader.css
+++ b/src/components/atoms/AccordionHeader/AccordionHeader.css
@@ -11,4 +11,5 @@
 
 .accordion-button.data-li {
   padding-right: 1rem;
+  font-weight: 900;
 }

--- a/src/components/atoms/AccordionHeader/AccordionHeader.css
+++ b/src/components/atoms/AccordionHeader/AccordionHeader.css
@@ -11,5 +11,4 @@
 
 .accordion-button.data-li {
   padding-right: 1rem;
-  font-weight: 900;
 }

--- a/src/components/atoms/AccordionHeader/AccordionHeader.js
+++ b/src/components/atoms/AccordionHeader/AccordionHeader.js
@@ -76,9 +76,17 @@ export default class AccordionHeader extends HTMLElement {
   addListNumber(index, extraClasses) {
     const accordionBtn = this.shadowRoot.querySelector('button');
     const numberBox = document.createElement('div');
-    numberBox.innerText = `${index + 1}`;
     extraClasses.push('li-num-box');
     numberBox.className = extraClasses.join(' ');
+    const numberSlot = document.createElement('slot');
+    numberSlot.setAttribute('name', 'li-num-box');
+    numberBox.appendChild(numberSlot);
     accordionBtn.prepend(numberBox);
+
+    // TODO: Match existing slot element and classes.
+    const number = document.createElement('span');
+    number.innerText = `${index + 1}`;
+    number.setAttribute('slot', 'li-num-box');
+    this.appendChild(number);
   }
 }

--- a/src/components/atoms/AccordionHeader/AccordionHeader.js
+++ b/src/components/atoms/AccordionHeader/AccordionHeader.js
@@ -5,7 +5,11 @@ import bootstrapStyles from '!!raw-loader!../../../shared/themed-bootstrap.css';
 const template = document.createElement('template');
 
 template.innerHTML = `
-<slot></slot>
+<div>
+  <button type="button" class="accordion-button" data-bs-toggle="collapse">
+    <slot></slot>
+  </button>
+</div>
 `;
 
 export default class AccordionHeader extends HTMLElement {
@@ -19,17 +23,6 @@ export default class AccordionHeader extends HTMLElement {
     // Create a shadow root
     const shadow = this.attachShadow({ mode: 'open' });
     shadow.appendChild(template.content.cloneNode(true));
-    this.accordionHeader = document.createElement('div');
-    this.accordionBtn = document.createElement('button');
-    this.accordionHeader.appendChild(this.accordionBtn);
-    this.shadowRoot.addEventListener('slotchange', (ev) => {
-      // TODO: See CityOfDetroit/detroitmi#1099
-      // eslint-disable-next-line prefer-const
-      let tempElements = ev.target.assignedElements();
-      tempElements.forEach((node) => {
-        this.accordionBtn.append(node);
-      });
-    });
 
     // Add styles
     const bootStyles = document.createElement('style');
@@ -44,10 +37,11 @@ export default class AccordionHeader extends HTMLElement {
   }
 
   attributeChangedCallback(name, oldValue, newValue) {
-    this.accordionBtn.setAttribute('aria-expanded', newValue);
+    const accordionBtn = this.shadowRoot.querySelector('button');
+    accordionBtn.setAttribute('aria-expanded', newValue);
     // TODO: See CityOfDetroit/detroitmi#1099
     // eslint-disable-next-line prefer-const
-    let tempClasses = this.accordionBtn.className.split(' ');
+    let tempClasses = accordionBtn.className.split(' ');
     // TODO: See CityOfDetroit/detroitmi#1099
     // eslint-disable-next-line prefer-const
     let popValue = tempClasses.pop();
@@ -59,56 +53,41 @@ export default class AccordionHeader extends HTMLElement {
     if (newValue == 'false') {
       tempClasses.push('collapsed');
     }
-    this.accordionBtn.className = tempClasses.join(' ');
+    accordionBtn.className = tempClasses.join(' ');
   }
 
   connectedCallback() {
-    // Nav attributes
-    // TODO: Refactor attribute and class handling.
-    // TODO: See CityOfDetroit/detroitmi#1099
-    // eslint-disable-next-line prefer-const
-    let parentID = this.getAttribute('data-parent-id');
-    // TODO: See CityOfDetroit/detroitmi#1099
-    // eslint-disable-next-line prefer-const
-    let expanded = this.getAttribute('data-expanded');
-    // TODO: See CityOfDetroit/detroitmi#1099
-    // eslint-disable-next-line prefer-const
-    let extraClasses = this.getAttribute('data-extra-classes');
+    const accordionBtn = this.shadowRoot.querySelector('button');
+    // Set classes.
+    const extraClasses = this.getAttribute('data-extra-classes');
     const isListItem = this.getAttribute('data-li');
-    // TODO: See CityOfDetroit/detroitmi#1099
-    // eslint-disable-next-line prefer-const
-    let accordionBtnClasses = ['accordion-button'];
     if (isListItem !== null) {
-      accordionBtnClasses.push('data-li');
+      accordionBtn.classList.add('data-li');
     }
-    this.accordionBtn.setAttribute('type', 'button');
-    this.accordionBtn.setAttribute('data-bs-toggle', 'collapse');
-    this.accordionBtn.setAttribute('aria-controls', parentID);
-    this.accordionBtn.setAttribute('data-bs-target', `#${parentID}`);
-    // TODO: See CityOfDetroit/detroitmi#1099
-    // eslint-disable-next-line eqeqeq
-    if (expanded == 'true') {
-      this.accordionBtn.setAttribute('aria-expanded', 'true');
+    if (extraClasses) {
+      accordionBtn.classList.add(...extraClasses.split(' '));
+    }
+
+    // Set attributes.
+    const parentID = this.getAttribute('data-parent-id');
+    accordionBtn.setAttribute('aria-controls', parentID);
+    accordionBtn.setAttribute('data-bs-target', `#${parentID}`);
+    const expanded = this.getAttribute('data-expanded');
+    if (expanded === 'true') {
+      accordionBtn.classList.remove('collapsed');
+      accordionBtn.setAttribute('aria-expanded', 'true');
     } else {
-      accordionBtnClasses.push('collapsed');
-      this.accordionBtn.setAttribute('aria-expanded', 'false');
-    }
-    // TODO: See CityOfDetroit/detroitmi#1099
-    // eslint-disable-next-line eqeqeq
-    extraClasses != undefined && extraClasses != null
-      ? accordionBtnClasses.push(extraClasses)
-      : 0;
-    this.accordionBtn.className = accordionBtnClasses.join(' ');
-    if (!this.shadowRoot.querySelector('div')) {
-      this.shadowRoot.appendChild(this.accordionHeader);
+      accordionBtn.classList.add('collapsed');
+      accordionBtn.setAttribute('aria-expanded', 'false');
     }
   }
 
   addListNumber(index, extraClasses) {
+    const accordionBtn = this.shadowRoot.querySelector('button');
     const numberBox = document.createElement('div');
     numberBox.innerText = `${index + 1}`;
     extraClasses.push('li-num-box');
     numberBox.className = extraClasses.join(' ');
-    this.accordionBtn.prepend(numberBox);
+    accordionBtn.prepend(numberBox);
   }
 }

--- a/src/components/atoms/AccordionHeader/AccordionHeader.js
+++ b/src/components/atoms/AccordionHeader/AccordionHeader.js
@@ -37,23 +37,14 @@ export default class AccordionHeader extends HTMLElement {
   }
 
   attributeChangedCallback(name, oldValue, newValue) {
-    const accordionBtn = this.shadowRoot.querySelector('button');
-    accordionBtn.setAttribute('aria-expanded', newValue);
-    // TODO: See CityOfDetroit/detroitmi#1099
-    // eslint-disable-next-line prefer-const
-    let tempClasses = accordionBtn.className.split(' ');
-    // TODO: See CityOfDetroit/detroitmi#1099
-    // eslint-disable-next-line prefer-const
-    let popValue = tempClasses.pop();
-    // TODO: See CityOfDetroit/detroitmi#1099
-    // eslint-disable-next-line eqeqeq
-    popValue != 'collapsed' ? tempClasses.push(popValue) : 0;
-    // TODO: See CityOfDetroit/detroitmi#1099
-    // eslint-disable-next-line eqeqeq
-    if (newValue == 'false') {
-      tempClasses.push('collapsed');
+    if (name === 'data-expanded') {
+      const accordionBtn = this.shadowRoot.querySelector('button');
+      accordionBtn.setAttribute('aria-expanded', newValue);
+      accordionBtn.classList.remove('collapsed');
+      if (newValue === 'false') {
+        accordionBtn.classList.add('collapsed');
+      }
     }
-    accordionBtn.className = tempClasses.join(' ');
   }
 
   connectedCallback() {

--- a/src/stories/accordion.stories.js
+++ b/src/stories/accordion.stories.js
@@ -206,7 +206,7 @@ export const List = () => html`
   <cod-accordion data-id="accordionListExample" data-ol="true">
     <cod-accordion-item>
       <cod-accordion-header>
-        <span>Accordion Item</span>
+        <h5 class="mb-0">Accordion Item</h5>
       </cod-accordion-header>
       <cod-accordion-body>
         <p>
@@ -223,7 +223,7 @@ export const List = () => html`
     </cod-accordion-item>
     <cod-accordion-item data-li-bg="success" data-li-text="dark">
       <cod-accordion-header>
-        <span>Accordion Item</span>
+        <h5 class="mb-0">Accordion Item</h5>
       </cod-accordion-header>
       <cod-accordion-body>
         <p>
@@ -240,7 +240,7 @@ export const List = () => html`
     </cod-accordion-item>
     <cod-accordion-item data-li-bg="warning" data-li-text="dark">
       <cod-accordion-header>
-        <span>Accordion Item</span>
+        <h5 class="mb-0">Accordion Item</h5>
       </cod-accordion-header>
       <cod-accordion-body>
         <p>


### PR DESCRIPTION
## Part of CityOfDetroit/detroitmi#1086

The goal of this stack of PRs will be to style our list-style accordion like so:
<img width="715" alt="265829089-6f26bf39-73af-40ab-8019-f25ddf43744b" src="https://github.com/CityOfDetroit/COD-Design-System/assets/143553259/e9659841-1319-4052-8b48-2b72d76459f8">

In order to do this, this stack of PRs does the following:
1. (This PR) Move all content in the accordion header into a slot. This way styling the content is left to the light DOM / user of the design system.
2. Adopt the element tag and classes of the header content for the list number (so it's styled the same in the light DOM).
3. Allow the design system user to select more color options for the accordion headers than the current BS theme (primary, secondary, danger, etc.).
4. Use new mixins (#140) to handle adding the list number to the accordion header during both slot change and attribute changed callback in case import order of components affects order of lifecycle events

## This PR

* Move all content in the accordion header into a slot. This way styling the content is left to the light DOM / user of the design system.
* Also a few more cosmetic changes since I already had to rewrite some of the component functions:
  * User HTMLElement.classList.add/remove instead of direct assignment.
  * Resolve ESLint errors.
  * Use `<h5>` in storybook for accordion headers to demonstrate the Light DOM styling advantage.