### PR TITLE
Create basic calendar component

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -11,5 +11,6 @@ rules: {
   no-else-return: [error],
   no-implicit-coercion: [warn],
   prefer-const: [error],
-  no-console: [error]
+  no-console: [error],
+  no-unused-vars: [error, { "argsIgnorePattern": "^_" }]
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@fullcalendar/core": "^6.1.11",
+    "@fullcalendar/daygrid": "^6.1.11",
     "bootstrap": "5.3.0-alpha3",
     "maplibre-gl": "^2.4.0"
   },

--- a/src/components/organisms/Calendar/Calendar.js
+++ b/src/components/organisms/Calendar/Calendar.js
@@ -1,0 +1,96 @@
+import styles from '!!raw-loader!./Calendar.css';
+import varStyles from '!!raw-loader!../../../shared/variables.css';
+import bootstrapStyles from '!!raw-loader!../../../shared/themed-bootstrap.css';
+
+import { Calendar as FullCalendar } from '@fullcalendar/core';
+import dayGridPlugin from '@fullcalendar/daygrid';
+
+const template = document.createElement('template');
+template.innerHTML = `
+<div id="calendar">
+</div>
+`;
+
+class Calendar extends HTMLElement {
+  static observedAttributes = [];
+
+  constructor() {
+    // Always call super first in constructor
+    super();
+    // Create a shadow root
+    this.attachShadow({ mode: 'open' });
+    this.shadowRoot.appendChild(template.content.cloneNode(true));
+
+    // Add styles
+    const bootStyles = document.createElement('style');
+    bootStyles.textContent = bootstrapStyles;
+    const variableStyles = document.createElement('style');
+    variableStyles.textContent = varStyles;
+    const itemStyles = document.createElement('style');
+    itemStyles.textContent = styles;
+    this.shadowRoot.appendChild(bootStyles);
+    this.shadowRoot.appendChild(variableStyles);
+    this.shadowRoot.appendChild(itemStyles);
+  }
+
+  connectedCallback() {
+    if (this.calendarIsConnected()) {
+      return;
+    }
+
+    const calendarEl = this.shadowRoot.getElementById('calendar');
+    const eventArraySource = this.buildEventArraySource();
+    const calendar = new FullCalendar(calendarEl, {
+      plugins: [dayGridPlugin],
+      initialView: 'dayGridMonth',
+      headerToolbar: {
+        left: 'title',
+        center: '',
+        right: 'prev,next today',
+      },
+      eventSources: [eventArraySource],
+    });
+    calendar.render();
+  }
+
+  /**
+   * Build an events source object from the JSON list of events
+   * provided by the user of the component.
+   * @returns an EventSource object using an array of events.
+   *          See https://fullcalendar.io/docs/event-source-object.
+   */
+  buildEventArraySource() {
+    let events = [];
+    const eventsJSON = this.getAttribute('events');
+    try {
+      events = JSON.parse(eventsJSON ?? '[]');
+    } catch (error) {
+      // TODO: Introduce proper error logging.
+      // eslint-disable-next-line no-console
+      console.error(`Failed to parse list of events:\n${eventsJSON}`);
+    }
+    const eventSource = {
+      id: 'eventsArray',
+      events: events,
+      // TODO: customize based on detroitmi theme and associated filters.
+      color: 'blue',
+      textColor: 'black',
+    };
+    return eventSource;
+  }
+
+  /**
+   * Checks if the calendar is already connected to the Shadow DOM.
+   * @returns true if the calendar element is already connected to
+   *          the Shadow DOM, and false otherwise.
+   */
+  calendarIsConnected() {
+    return this.shadowRoot.getElementById('calendar').childElementCount > 0;
+  }
+
+  // TODO: Handle event source changes.
+  // attributeChangedCallback(name, oldValue, newValue) {
+  // }
+}
+
+export { Calendar as default };

--- a/src/components/organisms/Calendar/cod-calendar.js
+++ b/src/components/organisms/Calendar/cod-calendar.js
@@ -1,0 +1,2 @@
+import Calendar from './Calendar';
+customElements.define('cod-calendar', Calendar);

--- a/src/stories/calendar.stories.js
+++ b/src/stories/calendar.stories.js
@@ -1,0 +1,31 @@
+import '../components/organisms/Calendar/cod-calendar';
+
+export default {
+  title: 'Components/Organisms/Calendar',
+  argTypes: {
+    events: {
+      control: { type: 'text' },
+      description:
+        'A JSON array of events conforming to the FullCalenar \
+      event model. See: https://fullcalendar.io/docs/event-model.',
+    },
+  },
+  args: {
+    events: JSON.stringify([
+      {
+        title: 'event1',
+        start: new Date().toISOString(),
+        allDay: true,
+      },
+    ]),
+  },
+};
+
+// Template
+const Template = (args) => {
+  const calendarElt = document.createElement('cod-calendar');
+  calendarElt.setAttribute('events', args.events);
+  return calendarElt;
+};
+
+export const Primary = Template.bind({});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3855,6 +3855,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@fullcalendar/core@npm:^6.1.11":
+  version: 6.1.11
+  resolution: "@fullcalendar/core@npm:6.1.11"
+  dependencies:
+    preact: ~10.12.1
+  checksum: 0078a6f96b06a637de08ba28a317bbcbf7768f53ce7891faa2a656ca2bed0e887e555d6f3203b77d6c271ccb128fa85d592411fcfd87746514a5cec68376ad87
+  languageName: node
+  linkType: hard
+
+"@fullcalendar/daygrid@npm:^6.1.11":
+  version: 6.1.11
+  resolution: "@fullcalendar/daygrid@npm:6.1.11"
+  peerDependencies:
+    "@fullcalendar/core": ~6.1.11
+  checksum: 6eb5606de58b7a8ec30d96618a6d15b2c0d7108c94593ff94e81a8d87ce8efb1f29f3849c6c3f2b8ae56198ffe6235e2ec0e4a1270993c022dc194016e595685
+  languageName: node
+  linkType: hard
+
 "@hapi/hoek@npm:^9.0.0":
   version: 9.3.0
   resolution: "@hapi/hoek@npm:9.3.0"
@@ -9613,6 +9631,8 @@ __metadata:
     "@babel/preset-env": ^7.16.0
     "@babel/preset-typescript": ^7.21.0
     "@babel/runtime": ^7.15.4
+    "@fullcalendar/core": ^6.1.11
+    "@fullcalendar/daygrid": ^6.1.11
     "@storybook/addon-a11y": ^7.3.2
     "@storybook/addon-actions": ^7.3.2
     "@storybook/addon-coverage": ^0.0.9
@@ -18868,6 +18888,13 @@ __metadata:
   version: 1.0.2
   resolution: "potpack@npm:1.0.2"
   checksum: 9dfdbbce012ce80842249abcdd89e20222eb8ae96beba8d578b7e41e78feefc7e33b5c72d46fb8dd3a1e382cb4da9c34574764d88aa8849ab36f542fd2088b42
+  languageName: node
+  linkType: hard
+
+"preact@npm:~10.12.1":
+  version: 10.12.1
+  resolution: "preact@npm:10.12.1"
+  checksum: 0de99f477563ab7f94a0f964952ad216375973c0dcd9eb49881f8eb5effc5ed6948da062548c87d5bb0d82f1a1e516b649020e760eab3a0503dfdd8e64d34a26
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Part of #182 

See context in #182.

In this stack of PRs, we'll:
1. (This PR) Introduce a new calendar component that accepts a static list of events
2. Extend the component to accept a list of filter controls, starting with a radio control that will filter events by an arbitrary 'category' field and value.

## This PR

* Update ESLint config to allow `_unusedvariablesStartingWithUnderscore`
* Include fullcalendar libraries in package dependencies
* Introduce a new calendar component that accepts a static list of events