### PR TITLE
Prevent hypothetical XSS

### DIFF
--- a/src/components/atoms/Icon/Icon.js
+++ b/src/components/atoms/Icon/Icon.js
@@ -32,6 +32,7 @@ export default class Icon extends HTMLElement {
         break;
 
       default:
+        size = '24';
         break;
     }
     const iconContainer = document.createElement('span');


### PR DESCRIPTION
# Part of #183 

See context and example of how the XSS could be exploited in #183.

## This PR

Prevent the possibility of user-input flowing into `innerHTML` and being interpreted as arbitrary JS by always using a static value for `size`.

Note: I chose to make the default `size` medium, but we could also set it as `null` which would effectively hide the icon from display unless `data-size` attr is set correctly. Medium felt like a more reasonable default.