### PR TITLE
Support event filters in calendar component

### DIFF
--- a/src/components/organisms/Calendar/Calendar.js
+++ b/src/components/organisms/Calendar/Calendar.js
@@ -62,6 +62,7 @@ class Calendar extends HTMLElement {
     this.calendar = new FullCalendar(calendarEl, {
       plugins: [dayGridPlugin],
       initialView: 'dayGridMonth',
+      height: 'auto',
       headerToolbar: {
         left: 'title',
         center: '',

--- a/src/components/organisms/Calendar/Calendar.js
+++ b/src/components/organisms/Calendar/Calendar.js
@@ -180,6 +180,11 @@ class Calendar extends HTMLElement {
           radioButtonInput.setAttribute('id', value);
           radioButtonInput.setAttribute('name', filter.key);
           radioButtonInput.setAttribute('value', value);
+          // Bind event handler to this instance.
+          radioButtonInput.addEventListener(
+            'click',
+            this.filterEvents.bind(this),
+          );
           radioButtonContainer.appendChild(radioButtonInput);
           const radioButtonLabel = document.createElement('label');
           radioButtonLabel.setAttribute('for', value);
@@ -197,6 +202,29 @@ class Calendar extends HTMLElement {
         return;
       }
     }
+  }
+
+  /**
+   * Handles filter element events by filter down events to the
+   * user-selected criteria.
+   *
+   * @param {Event} browserEvent - The browser event triggered on the filter
+   *        form element.
+   */
+  filterEvents(browserEvent) {
+    const inputKey = browserEvent.target.name;
+    const inputValue = browserEvent.target.value;
+    const currentEventsJSON = this.getAttribute('events');
+    let events = [];
+    try {
+      events = JSON.parse(currentEventsJSON ?? '[]');
+    } catch (error) {
+      // TODO: Introduce proper error logging.
+      // eslint-disable-next-line no-console
+      console.error(`Failed to parse list of events:\n${currentEventsJSON}`);
+    }
+    events = events.filter((calEvent) => calEvent[inputKey] === inputValue);
+    this.updateEventArraySource(JSON.stringify(events));
   }
 
   attributeChangedCallback(name, oldValue, newValue) {

--- a/src/components/organisms/Calendar/Calendar.js
+++ b/src/components/organisms/Calendar/Calendar.js
@@ -169,17 +169,25 @@ class Calendar extends HTMLElement {
     switch (filter.type) {
       case 'radio': {
         const radioFiltersContainer = document.createElement('fieldset');
+        radioFiltersContainer.classList.add(
+          'd-flex',
+          'flex-wrap',
+          'm-3',
+          'justify-content-center',
+        );
         const legend = document.createElement('legend');
         legend.classList.add('visually-hidden');
         legend.innerText = filter.legend;
         radioFiltersContainer.appendChild(legend);
         filter.values.forEach((value) => {
           const radioButtonContainer = document.createElement('div');
+          radioButtonContainer.classList.add('m-2');
           const radioButtonInput = document.createElement('input');
           radioButtonInput.setAttribute('type', 'radio');
           radioButtonInput.setAttribute('id', value);
           radioButtonInput.setAttribute('name', filter.key);
           radioButtonInput.setAttribute('value', value);
+          radioButtonInput.classList.add('btn-check');
           // Bind event handler to this instance.
           radioButtonInput.addEventListener(
             'click',
@@ -188,6 +196,7 @@ class Calendar extends HTMLElement {
           radioButtonContainer.appendChild(radioButtonInput);
           const radioButtonLabel = document.createElement('label');
           radioButtonLabel.setAttribute('for', value);
+          radioButtonLabel.classList.add('btn', 'btn-primary');
           radioButtonLabel.innerText = value;
           radioButtonContainer.appendChild(radioButtonLabel);
           radioFiltersContainer.appendChild(radioButtonContainer);

--- a/src/stories/calendar.stories.js
+++ b/src/stories/calendar.stories.js
@@ -9,6 +9,22 @@ export default {
         'A JSON array of events conforming to the FullCalenar \
       event model. See: https://fullcalendar.io/docs/event-model.',
     },
+    eventFilters: {
+      control: { type: 'text' },
+      description: `A JSON object of event filters to be applied. The filters
+        should take the following form:
+        {
+         "filter_name": {
+            type: "ui_filter_type",
+            legend: "A helpful legend.",
+            key: "event_field_key",
+            values: [
+              "event_field_key_value1",
+              "event_field_key_value2"
+            ],
+          }
+        }`,
+    },
   },
   args: {
     events: JSON.stringify([
@@ -18,6 +34,19 @@ export default {
         allDay: true,
       },
     ]),
+    eventFilters: JSON.stringify({
+      dei_category_filter: {
+        type: 'radio',
+        legend: 'Select a location filter:',
+        key: 'dei_location',
+        values: [
+          'Say Detroit Play Center',
+          'Senior Facility',
+          'Dick & Sandy Boys and Girls Club',
+          'Detroit Housing Commission',
+        ],
+      },
+    }),
   },
 };
 
@@ -25,6 +54,9 @@ export default {
 const Template = (args) => {
   const calendarElt = document.createElement('cod-calendar');
   calendarElt.setAttribute('events', args.events);
+  if (args.eventFilters) {
+    calendarElt.setAttribute('event-filters', args.eventFilters);
+  }
   return calendarElt;
 };
 

--- a/src/stories/calendar.stories.js
+++ b/src/stories/calendar.stories.js
@@ -29,16 +29,29 @@ export default {
   args: {
     events: JSON.stringify([
       {
-        title: 'event1',
+        title: 'event @ Say Detroit Play Center',
         start: new Date().toISOString(),
         allDay: true,
+        location: 'Say Detroit Play Center',
+      },
+      {
+        title: 'event @ Senior Facility',
+        start: new Date().toISOString(),
+        allDay: true,
+        location: 'Senior Facility',
+      },
+      {
+        title: 'event @ Detroit Housing Commission',
+        start: new Date().toISOString(),
+        allDay: true,
+        location: 'Detroit Housing Commission',
       },
     ]),
     eventFilters: JSON.stringify({
       dei_category_filter: {
         type: 'radio',
         legend: 'Select a location filter:',
-        key: 'dei_location',
+        key: 'location',
         values: [
           'Say Detroit Play Center',
           'Senior Facility',


### PR DESCRIPTION
## Part of #182 

See context in #182.

In this stack of PRs, we'll:
1. (Done) ~~Introduce a new calendar component that accepts a static list of events~~
2. (This PR) Extend the component to accept a list of filter controls, starting with a radio control that will filter events by an arbitrary 'category' field and value.
3. Support custom colors that will control the color of events on the calendar and event filters

## This PR

* Update `cod-calendar` component to support passing a list of event filters to the `event-filters` attribute
* Update storybook with an example of filters
* Update height of calendar to be responsive (allows height to grow on mobile when width is compressed)

## Testing

See storybook in chromatic and test various number of filters and scenarios (e.g. filter down to no events, go next and prev months after filter, etc.)