### PR TITLE
Issue.209

### DIFF
--- a/src/components/atoms/Progress/Progress.js
+++ b/src/components/atoms/Progress/Progress.js
@@ -34,63 +34,29 @@ export default class Progress extends HTMLElement {
 
     const backgroundColor = this.getAttribute('data-background-color');
 
-    const multiBarConfig = this.getAttribute('multi-bar-config');
     const progressContainer = document.createElement('div');
 
-    if (multiBarConfig === null) {
-      const bar = document.createElement('div');
-      bar.role = 'progressbar';
-      bar.setAttribute('aria-label', ariaLabel);
-      bar.setAttribute('aria-valuenow', value);
-      bar.className = 'progress';
-      const barBody = document.createElement('div');
-      barBody.style = `width: ${value}%`;
+    const bar = document.createElement('div');
+    bar.role = 'progressbar';
+    bar.setAttribute('aria-label', ariaLabel);
+    bar.setAttribute('aria-valuenow', value);
+    bar.className = 'progress';
+    const barBody = document.createElement('div');
+    barBody.style = `width: ${value}%`;
 
-      // TODO: Fix old ESLint errors - see issue #1099
-      // eslint-disable-next-line eqeqeq
-      if (label != 'undefined' && label != 'null') {
-        barBody.innerText = label;
-      }
-      barBody.className = [
-        'progress-bar',
-        `progress-bar-${animated || ''}`,
-        `progress-bar-${striped || ''}`,
-        `bg-${backgroundColor || ''}`,
-      ].join(' ');
-      bar.appendChild(barBody);
-      progressContainer.appendChild(bar);
-    } else {
-      progressContainer.className = 'progress-stacked';
-      this.buildBar(JSON.parse(multiBarConfig), progressContainer);
+    // TODO: Fix old ESLint errors - see issue #1099
+    // eslint-disable-next-line eqeqeq
+    if (label != 'undefined' && label != 'null') {
+      barBody.innerText = label;
     }
+    barBody.className = [
+      'progress-bar',
+      `progress-bar-${animated || ''}`,
+      `progress-bar-${striped || ''}`,
+      `bg-${backgroundColor || ''}`,
+    ].join(' ');
+    bar.appendChild(barBody);
+    progressContainer.appendChild(bar);
     this.shadowRoot.appendChild(progressContainer);
-  }
-
-  buildBar(bars, barContainer) {
-    bars.forEach((bar) => {
-      const tempBar = document.createElement('div');
-      tempBar.role = 'progressbar';
-      tempBar.setAttribute('aria-label', bar.ariaLabel);
-      tempBar.setAttribute('aria-valuenow', bar.value);
-      tempBar.setAttribute('aria-valuemin', '0');
-      tempBar.setAttribute('aria-valuemax', '100');
-      tempBar.className = 'progress';
-      const barBody = document.createElement('div');
-      tempBar.style = `width: ${bar.value}%`;
-
-      // TODO: Fix old ESLint errors - see issue #1099
-      // eslint-disable-next-line eqeqeq
-      bar.label == undefined || bar.label == null
-        ? ''
-        : (barBody.innerText = bar.label);
-      barBody.className = [
-        'progress-bar',
-        `progress-bar-${bar.animated || ''}`,
-        `progress-bar-${bar.striped || ''}`,
-        `bg-${bar.backgroundColor || ''}`,
-      ].join(' ');
-      tempBar.appendChild(barBody);
-      barContainer.appendChild(tempBar);
-    });
   }
 }

--- a/src/components/atoms/Progress/Progress.js
+++ b/src/components/atoms/Progress/Progress.js
@@ -34,12 +34,10 @@ export default class Progress extends HTMLElement {
 
     const backgroundColor = this.getAttribute('data-background-color');
 
-    const stacked = this.getAttribute('data-multi-bars');
+    const multiBarConfig = this.getAttribute('multi-bar-config');
     const progressContainer = document.createElement('div');
 
-    // TODO: Fix old ESLint errors - see issue #1099
-    // eslint-disable-next-line eqeqeq
-    if (stacked == 'undefined' || stacked == 'null') {
+    if (multiBarConfig === null) {
       const bar = document.createElement('div');
       bar.role = 'progressbar';
       bar.setAttribute('aria-label', ariaLabel);
@@ -63,7 +61,7 @@ export default class Progress extends HTMLElement {
       progressContainer.appendChild(bar);
     } else {
       progressContainer.className = 'progress-stacked';
-      this.buildBar(JSON.parse(stacked), progressContainer);
+      this.buildBar(JSON.parse(multiBarConfig), progressContainer);
     }
     this.shadowRoot.appendChild(progressContainer);
   }

--- a/src/stories/progress.stories.js
+++ b/src/stories/progress.stories.js
@@ -27,9 +27,6 @@ const Template = (args) => {
   progress.setAttribute('data-label', args.label);
   progress.setAttribute('data-aria-label', args.ariaLabel);
   progress.setAttribute('data-animated', args.animated);
-  if (args.multiBars) {
-    progress.setAttribute('multi-bar-config', args.multiBars);
-  }
   return progress;
 };
 
@@ -65,30 +62,4 @@ StripedBarLabel.args = {
   type: 'striped',
   animated: 'animated',
   label: 'this 25%',
-};
-
-export const StripedBarStacked = Template.bind({});
-StripedBarStacked.args = {
-  multiBars: JSON.stringify([
-    {
-      ariaLabel: 'first stacked bar',
-      value: '30',
-      label: 'Something 30%',
-      animated: 'animated',
-      striped: 'striped',
-      backgroundColor: 'info',
-    },
-    {
-      ariaLabel: 'second stacked bar',
-      value: '15',
-      animated: 'animated',
-      striped: 'striped',
-      backgroundColor: 'warning',
-    },
-    {
-      ariaLabel: 'second stacked bar',
-      value: '20',
-      backgroundColor: 'success',
-    },
-  ]),
 };

--- a/src/stories/progress.stories.js
+++ b/src/stories/progress.stories.js
@@ -27,7 +27,9 @@ const Template = (args) => {
   progress.setAttribute('data-label', args.label);
   progress.setAttribute('data-aria-label', args.ariaLabel);
   progress.setAttribute('data-animated', args.animated);
-  progress.setAttribute('data-multi-bars', args.multiBars);
+  if (args.multiBars) {
+    progress.setAttribute('multi-bar-config', args.multiBars);
+  }
   return progress;
 };
 


### PR DESCRIPTION
## Fixes #209

Previously, if `data-multi-bars` wasn't set to "undefined" or "<json-config>" then the entire progress bar would fail to get built in the DOM (except the container).

This PR:
* Removes support for multi-progress bar and associated attribute `data-multi-bars`

Removing support for this feature as the "fix" for a couple reasons:
1. If we want to support multi-bar styling, then a more HTML-looking API would be via component composition as opposed to passing a JSON configuration for child components. E.g. Imagine a new component `<cod-progress-multi-bar>` which allows nested `<cod-progress-bars>`.
2. I don't believe this feature is in use anywhere currently, so shouldn't be a problem to remove and re-add later when necessary.