### PR TITLE
Add GH action for GH pages deployment

### DIFF
--- a/.github/workflows/manual-gh-pages-deploy.yml
+++ b/.github/workflows/manual-gh-pages-deploy.yml
@@ -1,0 +1,27 @@
+name: Manual GH Pages Deployment
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16
+
+      - name: Install dependencies and build
+        run: |
+          yarn
+          yarn build-storybook --quiet
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./storybook-static


### PR DESCRIPTION
# Part of #224 

We'll have to manually test this in production environment since actions don't get registered on branches outside the main branch.