### PR TITLE
Fixes for CI workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Auto Release
 on:
   push:
     branches:
-      - main  # Only run on the main branch
+      - dev  # Only run on the dev branch
 
 jobs:
   release:

--- a/.github/workflows/storybook-tests.yml
+++ b/.github/workflows/storybook-tests.yml
@@ -1,7 +1,5 @@
 name: 'Storybook Tests'
 on:
-  push:
-    branches: [ dev ]
   pull_request:
     branches: [ dev ]
 jobs:


### PR DESCRIPTION
- Don't run storybook tests on main branch (since its protected anyway)
- Fix branch name in release workflow