### PR TITLE
Support translated content in gov banner

### DIFF
--- a/src/stable/components/GovBanner/GovBanner.js
+++ b/src/stable/components/GovBanner/GovBanner.js
@@ -1,77 +1,75 @@
 import styles from '!!raw-loader!./GovBanner.css';
 
-const template = document.createElement('template');
-template.innerHTML = `
-  <style>
-    ${styles}
-  </style>
-<div class="banner-container">
-  <header class="banner-header">
-    <div class="title-section">
-      <span class="city-name">
-        <span>City of</span>
-        <span>Detroit</span>
-      </span>
-      <div class="official-text">
-        An official website of the City of Detroit.
-        <button class="know-text" aria-expanded="false" aria-controls="content">
-        Here's how you know  
-        <span class="chevron-container">                
-            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-down" viewBox="0 0 16 16">
-              <path fill-rule="evenodd" d="M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708"/>
-            </svg>
-            </span>
-          </button>     
-      </div>
-    </div>
-  </header>
-  <div id="content" class="content-container" hidden>
-    <div class="info-section">
-      <div class="info-item">
-        <div class="icon-circle">
-          <span class="gov-icon">🏛️</span>
-        </div>
-        <div>
-          <span class="info-title">Official websites use .gov</span>
-          <p>A <b>.gov</b> website belongs to an official government organization in the United States.</p>
-        </div>
-      </div>
-      <div class="info-item">
-        <div class="icon-circle">
-          <span class="lock-icon">🔒</span>
-        </div>
-        <div>
-          <span class="info-title">Secure .gov websites use HTTPS</span>
-          <p>A <b>lock</b> (🔒) or <b>https://</b> means you've safely connected to the .gov website. Share sensitive information only on official, secure websites.</p>
-        </div>
-      </div>
-    </div>
-  </div>
-</div> 
-`;
+// Translation object for supported languages
+const translations = {
+  en: {
+    cityOf: 'City of',
+    cityName: 'Detroit',
+    officialWebsite: 'An official website of the City of Detroit.',
+    hereHowYouKnow: "Here's how you know",
+    officialWebsitesUseGov: 'Official websites use .gov',
+    govWebsiteDescription: 'A <b>.gov</b> website belongs to an official government organization in the United States.',
+    secureGovWebsites: 'Secure .gov websites use HTTPS',
+    httpsDescription: 'A <b>lock</b> (🔒) or <b>https://</b> means you\'ve safely connected to the .gov website. Share sensitive information only on official, secure websites.'
+  },
+  es: {
+    cityOf: 'Ciudad de',
+    cityName: 'Detroit',
+    officialWebsite: 'Un sitio web oficial de la Ciudad de Detroit.',
+    hereHowYouKnow: 'Así es como lo sabes',
+    officialWebsitesUseGov: 'Los sitios web oficiales usan .gov',
+    govWebsiteDescription: 'Un sitio web <b>.gov</b> pertenece a una organización gubernamental oficial de los Estados Unidos.',
+    secureGovWebsites: 'Los sitios web .gov seguros usan HTTPS',
+    httpsDescription: 'Un <b>candado</b> (🔒) o <b>https://</b> significa que te has conectado de forma segura al sitio web .gov. Comparte información confidencial solo en sitios web oficiales y seguros.'
+  },
+  ar: {
+    cityOf: 'مدينة',
+    cityName: 'ديترويت',
+    officialWebsite: 'موقع إلكتروني رسمي لمدينة ديترويت.',
+    hereHowYouKnow: 'إليك كيف تعرف',
+    officialWebsitesUseGov: 'المواقع الرسمية تستخدم .gov',
+    govWebsiteDescription: 'موقع <b>.gov</b> ينتمي إلى منظمة حكومية رسمية في الولايات المتحدة.',
+    secureGovWebsites: 'المواقع الآمنة .gov تستخدم HTTPS',
+    httpsDescription: '<b>القفل</b> (🔒) أو <b>https://</b> يعني أنك اتصلت بأمان بموقع .gov. شارك المعلومات الحساسة فقط على المواقع الرسمية والآمنة.'
+  },
+  bn: {
+    cityOf: 'শহর',
+    cityName: 'ডেট্রয়েট',
+    officialWebsite: 'ডেট্রয়েট শহরের একটি সরকারি ওয়েবসাইট।',
+    hereHowYouKnow: 'আপনি কীভাবে জানবেন',
+    officialWebsitesUseGov: 'সরকারি ওয়েবসাইটগুলি .gov ব্যবহার করে',
+    govWebsiteDescription: 'একটি <b>.gov</b> ওয়েবসাইট মার্কিন যুক্তরাষ্ট্রের একটি সরকারি সংস্থার অন্তর্গত।',
+    secureGovWebsites: 'নিরাপদ .gov ওয়েবসাইটগুলি HTTPS ব্যবহার করে',
+    httpsDescription: 'একটি <b>তালা</b> (🔒) বা <b>https://</b> মানে আপনি .gov ওয়েবসাইটের সাথে নিরাপদে সংযুক্ত হয়েছেন। শুধুমাত্র সরকারি, নিরাপদ ওয়েবসাইটে সংবেদনশীল তথ্য শেয়ার করুন।'
+  }
+};
 
 class GovBanner extends HTMLElement {
   static get observedAttributes() {
-    return ['expanded'];
+    return ['expanded', 'lang', 'dir'];
   }
 
   constructor() {
     super();
-    const shadow = this.attachShadow({ mode: 'open' });
-    shadow.appendChild(template.content.cloneNode(true));
-    this.expanded = false;
+    this.attachShadow({ mode: 'open' });
+    this._expanded = false;
+    this._lang = 'en';
+    this._dir = 'ltr';
+    this._renderTemplate();
   }
 
   get expanded() {
-    return this.hasAttribute('expanded');
+    return this._expanded;
   }
 
   set expanded(value) {
     const isExpanded = Boolean(value);
 
-    if (isExpanded === this.expanded) {
+    if (isExpanded === this._expanded) {
       return;
     }
+
+    this._expanded = isExpanded;
 
     if (isExpanded) {
       this.setAttribute('expanded', '');
@@ -85,30 +83,133 @@ class GovBanner extends HTMLElement {
         bubbles: true,
       }),
     );
+
+    this._updateExpandedState(isExpanded);
+  }
+
+  get lang() {
+    return this.getAttribute('lang') || 'en';
+  }
+
+  set lang(value) {
+    if (value) {
+      this.setAttribute('lang', value);
+    } else {
+      this.removeAttribute('lang');
+    }
+  }
+
+  get dir() {
+    return this.getAttribute('dir') || 'ltr';
+  }
+
+  set dir(value) {
+    if (value) {
+      this.setAttribute('dir', value);
+    } else {
+      this.removeAttribute('dir');
+    }
+  }
+
+  _renderTemplate() {
+    const currentLang = this.lang;
+    const currentDir = this.dir;
+    const t = translations[currentLang] || translations.en;
+    
+    this.shadowRoot.innerHTML = `
+      <style>
+        ${styles}
+      </style>
+    <div class="banner-container" dir="${currentDir}">
+      <header class="banner-header">
+        <div class="title-section">
+          <span class="city-name">
+            <span>${t.cityOf}</span>
+            <span>${t.cityName}</span>
+          </span>
+          <div class="official-text">
+            ${t.officialWebsite}
+            <button class="know-text" aria-expanded="false" aria-controls="content">
+            ${t.hereHowYouKnow}
+            <span class="chevron-container">                
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-down" viewBox="0 0 16 16">
+                  <path fill-rule="evenodd" d="M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708"/>
+                </svg>
+                </span>
+              </button>     
+          </div>
+        </div>
+      </header>
+      <div id="content" class="content-container" hidden>
+        <div class="info-section">
+          <div class="info-item">
+            <div class="icon-circle">
+              <span class="gov-icon">🏛️</span>
+            </div>
+            <div>
+              <span class="info-title">${t.officialWebsitesUseGov}</span>
+              <p>${t.govWebsiteDescription}</p>
+            </div>
+          </div>
+          <div class="info-item">
+            <div class="icon-circle">
+              <span class="lock-icon">🔒</span>
+            </div>
+            <div>
+              <span class="info-title">${t.secureGovWebsites}</span>
+              <p>${t.httpsDescription}</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div> 
+    `;
   }
 
   connectedCallback() {
+    // Initialize expanded state from attribute if present
+    if (this.hasAttribute('expanded')) {
+      this._expanded = true;
+    }
     this._setupListeners();
-    this._updateExpandedState(this.expanded);
+    this._updateExpandedState(this._expanded);
   }
 
   disconnectedCallback() {
-    const toggle = this.shadowRoot.querySelector('.chevron-container');
-    toggle.removeEventListener('click', this._handleToggle);
+    const toggleButton = this.shadowRoot.querySelector('.know-text');
+    if (toggleButton && this._handleToggle) {
+      toggleButton.removeEventListener('click', this._handleToggle);
+    }
   }
 
-  attributeChangedCallback(name) {
+  attributeChangedCallback(name, oldValue, newValue) {
     if (name === 'expanded') {
-      this._updateExpandedState(this.hasAttribute('expanded'));
+      // Only update internal state if it differs from attribute state
+      const hasAttribute = this.hasAttribute('expanded');
+      if (this._expanded !== hasAttribute) {
+        this._expanded = hasAttribute;
+        this._updateExpandedState(this._expanded);
+      }
+    } else if (name === 'lang' || name === 'dir') {
+      // Re-render the template when language or direction changes
+      if (oldValue !== newValue) {
+        this._renderTemplate();
+        // Re-setup listeners and state after re-rendering
+        this._setupListeners();
+        this._updateExpandedState(this._expanded);
+      }
     }
   }
 
   _setupListeners() {
     const toggleButton = this.shadowRoot.querySelector('.know-text');
-    if (toggleButton) {
-      toggleButton.addEventListener('click', this._handleToggle.bind(this));
+    if (toggleButton && !toggleButton._govBannerListenerAttached) {
+      this._handleToggle = this._handleToggle.bind(this);
+      toggleButton.addEventListener('click', this._handleToggle);
+      toggleButton._govBannerListenerAttached = true;
     }
   }
+
   _handleToggle() {
     this.expanded = !this.expanded;
   }

--- a/src/stable/components/GovBanner/GovBanner.js
+++ b/src/stable/components/GovBanner/GovBanner.js
@@ -8,9 +8,11 @@ const translations = {
     officialWebsite: 'An official website of the City of Detroit.',
     hereHowYouKnow: "Here's how you know",
     officialWebsitesUseGov: 'Official websites use .gov',
-    govWebsiteDescription: 'A <b>.gov</b> website belongs to an official government organization in the United States.',
+    govWebsiteDescription:
+      'A <b>.gov</b> website belongs to an official government organization in the United States.',
     secureGovWebsites: 'Secure .gov websites use HTTPS',
-    httpsDescription: 'A <b>lock</b> (🔒) or <b>https://</b> means you\'ve safely connected to the .gov website. Share sensitive information only on official, secure websites.'
+    httpsDescription:
+      "A <b>lock</b> (🔒) or <b>https://</b> means you've safely connected to the .gov website. Share sensitive information only on official, secure websites.",
   },
   es: {
     cityOf: 'Ciudad de',
@@ -18,9 +20,11 @@ const translations = {
     officialWebsite: 'Un sitio web oficial de la Ciudad de Detroit.',
     hereHowYouKnow: 'Así es como lo sabes',
     officialWebsitesUseGov: 'Los sitios web oficiales usan .gov',
-    govWebsiteDescription: 'Un sitio web <b>.gov</b> pertenece a una organización gubernamental oficial de los Estados Unidos.',
+    govWebsiteDescription:
+      'Un sitio web <b>.gov</b> pertenece a una organización gubernamental oficial de los Estados Unidos.',
     secureGovWebsites: 'Los sitios web .gov seguros usan HTTPS',
-    httpsDescription: 'Un <b>candado</b> (🔒) o <b>https://</b> significa que te has conectado de forma segura al sitio web .gov. Comparte información confidencial solo en sitios web oficiales y seguros.'
+    httpsDescription:
+      'Un <b>candado</b> (🔒) o <b>https://</b> significa que te has conectado de forma segura al sitio web .gov. Comparte información confidencial solo en sitios web oficiales y seguros.',
   },
   ar: {
     cityOf: 'مدينة',
@@ -28,9 +32,11 @@ const translations = {
     officialWebsite: 'موقع إلكتروني رسمي لمدينة ديترويت.',
     hereHowYouKnow: 'إليك كيف تعرف',
     officialWebsitesUseGov: 'المواقع الرسمية تستخدم .gov',
-    govWebsiteDescription: 'موقع <b>.gov</b> ينتمي إلى منظمة حكومية رسمية في الولايات المتحدة.',
+    govWebsiteDescription:
+      'موقع <b>.gov</b> ينتمي إلى منظمة حكومية رسمية في الولايات المتحدة.',
     secureGovWebsites: 'المواقع الآمنة .gov تستخدم HTTPS',
-    httpsDescription: '<b>القفل</b> (🔒) أو <b>https://</b> يعني أنك اتصلت بأمان بموقع .gov. شارك المعلومات الحساسة فقط على المواقع الرسمية والآمنة.'
+    httpsDescription:
+      '<b>القفل</b> (🔒) أو <b>https://</b> يعني أنك اتصلت بأمان بموقع .gov. شارك المعلومات الحساسة فقط على المواقع الرسمية والآمنة.',
   },
   bn: {
     cityOf: 'শহর',
@@ -38,10 +44,12 @@ const translations = {
     officialWebsite: 'ডেট্রয়েট শহরের একটি সরকারি ওয়েবসাইট।',
     hereHowYouKnow: 'আপনি কীভাবে জানবেন',
     officialWebsitesUseGov: 'সরকারি ওয়েবসাইটগুলি .gov ব্যবহার করে',
-    govWebsiteDescription: 'একটি <b>.gov</b> ওয়েবসাইট মার্কিন যুক্তরাষ্ট্রের একটি সরকারি সংস্থার অন্তর্গত।',
+    govWebsiteDescription:
+      'একটি <b>.gov</b> ওয়েবসাইট মার্কিন যুক্তরাষ্ট্রের একটি সরকারি সংস্থার অন্তর্গত।',
     secureGovWebsites: 'নিরাপদ .gov ওয়েবসাইটগুলি HTTPS ব্যবহার করে',
-    httpsDescription: 'একটি <b>তালা</b> (🔒) বা <b>https://</b> মানে আপনি .gov ওয়েবসাইটের সাথে নিরাপদে সংযুক্ত হয়েছেন। শুধুমাত্র সরকারি, নিরাপদ ওয়েবসাইটে সংবেদনশীল তথ্য শেয়ার করুন।'
-  }
+    httpsDescription:
+      'একটি <b>তালা</b> (🔒) বা <b>https://</b> মানে আপনি .gov ওয়েবসাইটের সাথে নিরাপদে সংযুক্ত হয়েছেন। শুধুমাত্র সরকারি, নিরাপদ ওয়েবসাইটে সংবেদনশীল তথ্য শেয়ার করুন।',
+  },
 };
 
 class GovBanner extends HTMLElement {
@@ -115,7 +123,7 @@ class GovBanner extends HTMLElement {
     const currentLang = this.lang;
     const currentDir = this.dir;
     const t = translations[currentLang] || translations.en;
-    
+
     this.shadowRoot.innerHTML = `
       <style>
         ${styles}

--- a/src/stable/components/GovBanner/GovBanner.scss
+++ b/src/stable/components/GovBanner/GovBanner.scss
@@ -15,12 +15,22 @@
   padding: 0.5rem 1rem;
   max-width: 1200px;
   margin: 0 auto;
+  
+  // RTL support
+  [dir="rtl"] & {
+    direction: rtl;
+  }
 }
 
 .title-section {
   display: flex;
   align-items: center;
   gap: 1rem;
+  
+  // RTL support - reverse the order and adjust spacing
+  [dir="rtl"] & {
+    flex-direction: row-reverse;
+  }
 }
 
 .city-name {
@@ -63,6 +73,12 @@
     color: inherit;
     padding: 0;
     font-size: inherit;
+    
+    // RTL support - adjust margin
+    [dir="rtl"] & {
+      margin-left: 0;
+      margin-right: 0.25rem;
+    }
 
     &:focus {
       outline: none;
@@ -78,6 +94,12 @@
       display: inline-flex;
       align-items: center;
       margin-left: 0.25rem;
+      
+      // RTL support - adjust margin
+      [dir="rtl"] & {
+        margin-left: 0;
+        margin-right: 0.25rem;
+      }
 
       svg {
         transition: transform 0.2s ease;
@@ -96,6 +118,11 @@
   background-color: #f8f9fa;
   width: 100%;
   border-top: 1px solid #dee2e6;
+  
+  // RTL support
+  [dir="rtl"] & {
+    direction: rtl;
+  }
 }
 
 .info-section {
@@ -105,6 +132,11 @@
   margin: 0 auto;
   padding: 1.5rem 1rem;
   gap: 2rem;
+  
+  // RTL support
+  [dir="rtl"] & {
+    flex-direction: row-reverse;
+  }
 }
 
 .info-item {
@@ -112,12 +144,19 @@
   gap: 1rem;
   align-items: flex-start;
   flex: 1;
+  
+  // RTL support - reverse the flex direction for Arabic
+  [dir="rtl"] & {
+    flex-direction: row-reverse;
+    text-align: right;
+  }
 
   .info-title {
     margin: 0 0 0.5rem 0;
     font-size: 1rem;
     font-weight: 600;
     color: #212529;
+    display: block;
   }
 
   p {
@@ -160,6 +199,12 @@
     justify-content: center;
     margin-top: 0.0625rem;
     width: 100%;
+    
+    // RTL support - reset margins for mobile
+    [dir="rtl"] & {
+      margin-left: 0;
+      margin-right: 0;
+    }
   }
 
   .city-name {
@@ -174,12 +219,22 @@
     justify-content: flex-start;
     padding-top: 0.75rem;
     padding-bottom: 0.75rem;
+    
+    // RTL support - adjust alignment for mobile
+    [dir="rtl"] & {
+      justify-content: flex-end;
+    }
   }
 
   .official-text {
     align-items: flex-start;
     text-align: center;
     word-wrap: break-word;
+    
+    // RTL support
+    [dir="rtl"] & {
+      align-items: flex-end;
+    }
   }
 
   .info-section {

--- a/src/stable/components/GovBanner/GovBanner.scss
+++ b/src/stable/components/GovBanner/GovBanner.scss
@@ -15,9 +15,9 @@
   padding: 0.5rem 1rem;
   max-width: 1200px;
   margin: 0 auto;
-  
+
   // RTL support
-  [dir="rtl"] & {
+  [dir='rtl'] & {
     direction: rtl;
   }
 }
@@ -26,9 +26,9 @@
   display: flex;
   align-items: center;
   gap: 1rem;
-  
+
   // RTL support - reverse the order and adjust spacing
-  [dir="rtl"] & {
+  [dir='rtl'] & {
     flex-direction: row-reverse;
   }
 }
@@ -73,9 +73,9 @@
     color: inherit;
     padding: 0;
     font-size: inherit;
-    
+
     // RTL support - adjust margin
-    [dir="rtl"] & {
+    [dir='rtl'] & {
       margin-left: 0;
       margin-right: 0.25rem;
     }
@@ -94,9 +94,9 @@
       display: inline-flex;
       align-items: center;
       margin-left: 0.25rem;
-      
+
       // RTL support - adjust margin
-      [dir="rtl"] & {
+      [dir='rtl'] & {
         margin-left: 0;
         margin-right: 0.25rem;
       }
@@ -118,9 +118,9 @@
   background-color: #f8f9fa;
   width: 100%;
   border-top: 1px solid #dee2e6;
-  
+
   // RTL support
-  [dir="rtl"] & {
+  [dir='rtl'] & {
     direction: rtl;
   }
 }
@@ -132,9 +132,9 @@
   margin: 0 auto;
   padding: 1.5rem 1rem;
   gap: 2rem;
-  
+
   // RTL support
-  [dir="rtl"] & {
+  [dir='rtl'] & {
     flex-direction: row-reverse;
   }
 }
@@ -144,9 +144,9 @@
   gap: 1rem;
   align-items: flex-start;
   flex: 1;
-  
+
   // RTL support - reverse the flex direction for Arabic
-  [dir="rtl"] & {
+  [dir='rtl'] & {
     flex-direction: row-reverse;
     text-align: right;
   }
@@ -199,9 +199,9 @@
     justify-content: center;
     margin-top: 0.0625rem;
     width: 100%;
-    
+
     // RTL support - reset margins for mobile
-    [dir="rtl"] & {
+    [dir='rtl'] & {
       margin-left: 0;
       margin-right: 0;
     }
@@ -219,9 +219,9 @@
     justify-content: flex-start;
     padding-top: 0.75rem;
     padding-bottom: 0.75rem;
-    
+
     // RTL support - adjust alignment for mobile
-    [dir="rtl"] & {
+    [dir='rtl'] & {
       justify-content: flex-end;
     }
   }
@@ -230,9 +230,9 @@
     align-items: flex-start;
     text-align: center;
     word-wrap: break-word;
-    
+
     // RTL support
-    [dir="rtl"] & {
+    [dir='rtl'] & {
       align-items: flex-end;
     }
   }

--- a/src/stable/stories/govbanner.stories.js
+++ b/src/stable/stories/govbanner.stories.js
@@ -6,11 +6,54 @@ import '../components/GovBanner/cod-gov-banner';
 export default {
   tags: ['stable'],
   title: 'Components/Gov Banner',
+  argTypes: {
+    lang: {
+      control: 'select',
+      options: ['en', 'es', 'ar', 'bn'],
+      description: 'Language code for the banner content'
+    },
+    dir: {
+      control: 'select', 
+      options: ['ltr', 'rtl'],
+      description: 'Text direction (left-to-right or right-to-left)'
+    },
+    expanded: {
+      control: 'boolean',
+      description: 'Whether the info section is expanded'
+    }
+  }
 };
 
 export const GovBanner = {
   tags: ['autodocs'],
-  render: () => html` <cod-gov-banner> </cod-gov-banner> `,
+  args: {
+    lang: 'en',
+    dir: 'ltr',
+    expanded: false
+  },
+  render: ({ lang, dir, expanded }) => html`
+    <cod-gov-banner 
+      lang="${lang}" 
+      dir="${dir}"
+      ?expanded="${expanded}">
+    </cod-gov-banner>
+  `,
+};
+
+export const English = {
+  render: () => html` <cod-gov-banner lang="en" dir="ltr"> </cod-gov-banner> `,
+};
+
+export const Spanish = {
+  render: () => html` <cod-gov-banner lang="es" dir="ltr"> </cod-gov-banner> `,
+};
+
+export const Arabic = {
+  render: () => html` <cod-gov-banner lang="ar" dir="rtl"> </cod-gov-banner> `,
+};
+
+export const Bengali = {
+  render: () => html` <cod-gov-banner lang="bn" dir="ltr"> </cod-gov-banner> `,
 };
 
 export const Test = {
@@ -74,12 +117,21 @@ export const Test = {
     await expect(govBanner.expanded).toBe(false);
     checkExpandedState(false);
 
+    // Test language switching
+    govBanner.lang = 'es';
+    expect(govBanner.lang).toBe('es');
+    
+    govBanner.lang = 'ar';
+    expect(govBanner.lang).toBe('ar');
+    
+    govBanner.dir = 'rtl';
+    expect(govBanner.dir).toBe('rtl');
+
     // Test disconnectedCallback
     govBanner.remove();
 
     // Test setting same value (should not trigger event)
     govBanner.expanded = false;
     await expect(govBanner.expanded).toBe(false);
-    checkExpandedState(false);
   },
 };

--- a/src/stable/stories/govbanner.stories.js
+++ b/src/stable/stories/govbanner.stories.js
@@ -10,18 +10,18 @@ export default {
     lang: {
       control: 'select',
       options: ['en', 'es', 'ar', 'bn'],
-      description: 'Language code for the banner content'
+      description: 'Language code for the banner content',
     },
     dir: {
-      control: 'select', 
+      control: 'select',
       options: ['ltr', 'rtl'],
-      description: 'Text direction (left-to-right or right-to-left)'
+      description: 'Text direction (left-to-right or right-to-left)',
     },
     expanded: {
       control: 'boolean',
-      description: 'Whether the info section is expanded'
-    }
-  }
+      description: 'Whether the info section is expanded',
+    },
+  },
 };
 
 export const GovBanner = {
@@ -29,13 +29,10 @@ export const GovBanner = {
   args: {
     lang: 'en',
     dir: 'ltr',
-    expanded: false
+    expanded: false,
   },
   render: ({ lang, dir, expanded }) => html`
-    <cod-gov-banner 
-      lang="${lang}" 
-      dir="${dir}"
-      ?expanded="${expanded}">
+    <cod-gov-banner lang="${lang}" dir="${dir}" ?expanded="${expanded}">
     </cod-gov-banner>
   `,
 };
@@ -120,10 +117,10 @@ export const Test = {
     // Test language switching
     govBanner.lang = 'es';
     expect(govBanner.lang).toBe('es');
-    
+
     govBanner.lang = 'ar';
     expect(govBanner.lang).toBe('ar');
-    
+
     govBanner.dir = 'rtl';
     expect(govBanner.dir).toBe('rtl');
 


### PR DESCRIPTION
Part of CityOfDetroit/detroitmi#2187

## This PR

- Add support for `lang` and `dir` attributes on the gov banner, show translated content when requested
- Update expanded internal state to decouple from attribute and event handler (to prevent duplicate click events cancelling each other out)

## Testing

Update storybook interaction test and test manually: https://65a994a97db54752e77a065c-uolbaqwbbn.chromatic.com/?path=/docs/components-gov-banner--docs

![image](https://github.com/user-attachments/assets/afcd52b3-d5c1-4fcd-9da4-5f8d444a21d6)
