### PR TITLE
Fix cod-button form submit/reset in 3.x

### DIFF
--- a/src/stable/components/Button/Button.js
+++ b/src/stable/components/Button/Button.js
@@ -27,6 +27,7 @@ export default class Button extends HTMLElement {
       'target',
       'download',
       'rel',
+      'type',
       'square',
     ];
   }
@@ -53,6 +54,7 @@ export default class Button extends HTMLElement {
       target: '',
       download: '',
       rel: '',
+      type: 'submit',
       square: false,
     };
 
@@ -98,6 +100,9 @@ export default class Button extends HTMLElement {
       case 'rel':
         this._state.rel = newValue || '';
         break;
+      case 'type':
+        this._state.type = this._normalizeType(newValue);
+        break;
       case 'square':
         this._state.square = newValue !== null;
         break;
@@ -122,6 +127,7 @@ export default class Button extends HTMLElement {
     this._state.target = this.getAttribute('target') || '';
     this._state.download = this.getAttribute('download') || '';
     this._state.rel = this.getAttribute('rel') || '';
+    this._state.type = this._normalizeType(this.getAttribute('type'));
     this._state.square = this.hasAttribute('square');
 
     // Initial render
@@ -206,6 +212,8 @@ export default class Button extends HTMLElement {
       if (this._state.download) {
         element.download = this._state.download;
       }
+    } else {
+      element.type = this._state.type;
     }
 
     // Handle disabled state
@@ -359,7 +367,43 @@ export default class Button extends HTMLElement {
     if (this._state.disabled || this._state.loading) {
       event.preventDefault();
       event.stopPropagation();
+      return;
     }
+
+    if (this._state.href || this._state.type === 'button') {
+      return;
+    }
+
+    const form = this.closest('form');
+    if (!form) {
+      return;
+    }
+
+    queueMicrotask(() => {
+      if (event.defaultPrevented) {
+        return;
+      }
+
+      if (this._state.type === 'reset') {
+        form.reset();
+        return;
+      }
+
+      if (typeof form.requestSubmit === 'function') {
+        form.requestSubmit();
+      } else {
+        form.submit();
+      }
+    });
+  }
+
+  _normalizeType(typeValue) {
+    const normalizedType = (typeValue || 'submit').toLowerCase();
+    if (['submit', 'reset', 'button'].includes(normalizedType)) {
+      return normalizedType;
+    }
+
+    return 'submit';
   }
 
   // Getters and setters


### PR DESCRIPTION
This updates `cod-button` so it can submit and reset parent forms again in 3.x.

What changed:
- support a `type` attribute on the component (`submit`, `reset`, `button`, default `submit`)
- mirror that type onto the internal native `button`
- on click, when inside a form and not disabled/loading/link mode, call the form action directly:
  - `requestSubmit()` for submit (fallback to `submit()`)
  - `reset()` for reset

This matches expected button behavior for forms while keeping current link behavior unchanged.

Fixes #352

Tested locally:
- `npx eslint src/stable/components/Button/Button.js`
- `npx prettier --check src/stable/components/Button/Button.js`
- `npm run build:stable`