### PR TITLE
Fix modal close buttons after button API changes

### DIFF
--- a/src/experimental/components/atoms/ModalFooter/ModalFooter.js
+++ b/src/experimental/components/atoms/ModalFooter/ModalFooter.js
@@ -16,7 +16,7 @@ export default class ModalFooter extends HTMLElement {
     const shadow = this.attachShadow({ mode: 'open' });
     shadow.appendChild(template.content.cloneNode(true));
     this.modalFooter = document.createElement('div');
-    this.closeBtn = document.createElement('cod-button');
+    this.closeBtn = document.createElement('button');
 
     this.shadowRoot.addEventListener('slotchange', () => {
       const tempElements = Array.from(this.children);
@@ -46,9 +46,17 @@ export default class ModalFooter extends HTMLElement {
     const extraClasses = this.getAttribute('data-extra-classes');
 
     const modalFooterClasses = ['modal-footer'];
-    this.closeBtn.setAttribute('data-img-alt', '');
-    this.closeBtn.setAttribute('data-icon', '');
-    this.closeBtn.setAttribute('data-label', 'Close');
+    const closeBtnClasses = ['btn'];
+
+    if (btnExtraClasses !== undefined && btnExtraClasses !== null) {
+      closeBtnClasses.push(...btnExtraClasses.split(' ').filter(Boolean));
+    } else {
+      closeBtnClasses.push('btn-secondary');
+    }
+
+    this.closeBtn.type = 'button';
+    this.closeBtn.className = closeBtnClasses.join(' ');
+    this.closeBtn.textContent = 'Close';
     this.closeBtn.setAttribute('data-bs-dismiss', 'modal');
 
     // TODO: Fix old ESLint errors - see issue #1099
@@ -57,11 +65,6 @@ export default class ModalFooter extends HTMLElement {
       ? modalFooterClasses.push(extraClasses)
       : 0;
 
-    // TODO: Fix old ESLint errors - see issue #1099
-    // eslint-disable-next-line eqeqeq
-    btnExtraClasses != undefined && btnExtraClasses != null
-      ? this.closeBtn.setAttribute('data-extra-classes', btnExtraClasses)
-      : 0;
     this.modalFooter.className = modalFooterClasses.join(' ');
     this.closeBtn.addEventListener('click', this._onClick);
     if (!this.shadowRoot.querySelector('div')) {

--- a/src/experimental/components/atoms/ModalHeader/ModalHeader.js
+++ b/src/experimental/components/atoms/ModalHeader/ModalHeader.js
@@ -17,7 +17,7 @@ export default class ModalHeader extends HTMLElement {
     shadow.appendChild(template.content.cloneNode(true));
     this.modalHeader = document.createElement('div');
     this.modalTitle = document.createElement('div');
-    this.closeBtn = document.createElement('cod-button');
+    this.closeBtn = document.createElement('button');
 
     this.shadowRoot.addEventListener('slotchange', () => {
       const tempElements = Array.from(this.children);
@@ -52,9 +52,9 @@ export default class ModalHeader extends HTMLElement {
     const modalHeaderClasses = ['modal-header'];
     this.modalTitle.className = 'modal-title';
     this.modalTitle.id = `${parentID}-label`;
-    this.closeBtn.setAttribute('data-img-alt', '');
-    this.closeBtn.setAttribute('data-icon', '');
-    this.closeBtn.setAttribute('data-close', 'true');
+    this.closeBtn.type = 'button';
+    this.closeBtn.className = 'btn-close';
+    this.closeBtn.setAttribute('aria-label', 'Close');
     this.closeBtn.setAttribute('data-bs-dismiss', 'modal');
 
     // TODO: Fix old ESLint errors - see issue #1099
@@ -65,9 +65,7 @@ export default class ModalHeader extends HTMLElement {
 
     // TODO: Fix old ESLint errors - see issue #1099
     // eslint-disable-next-line eqeqeq
-    btnDark == 'true'
-      ? this.closeBtn.setAttribute('data-extra-classes', 'btn-close-white')
-      : 0;
+    btnDark == 'true' ? this.closeBtn.classList.add('btn-close-white') : 0;
     this.modalHeader.className = modalHeaderClasses.join(' ');
     this.closeBtn.addEventListener('click', this._onClick);
     if (!this.shadowRoot.querySelector('div')) {


### PR DESCRIPTION
The modal header and footer were still creating cod-button instances with old data attributes from the pre-3.x button API. That setup now throws runtime errors when the modal renders.\n\nThis switches those controls to native button elements with Bootstrap modal classes and keeps data-button-extra-classes support for the footer close button.\n\nI ran:\n- npx eslint src/experimental/components/atoms/ModalHeader/ModalHeader.js src/experimental/components/atoms/ModalFooter/ModalFooter.js\n- npx prettier --check src/experimental/components/atoms/ModalHeader/ModalHeader.js src/experimental/components/atoms/ModalFooter/ModalFooter.js\n- yarn build:experimental\n\nFixes #355