### PR TITLE
Fix striped table attribute propagation after upgrade

### DIFF
--- a/src/experimental/components/atoms/TableBody/TableBody.js
+++ b/src/experimental/components/atoms/TableBody/TableBody.js
@@ -14,12 +14,77 @@ template.innerHTML = `
 <slot></slot>
 `;
 
+function shouldSetBooleanAttribute(value) {
+  return value === 'true';
+}
+
+function setOrRemoveAttribute(element, attributeName, shouldSet) {
+  if (!element) {
+    return;
+  }
+
+  if (shouldSet) {
+    element.setAttribute(attributeName, 'true');
+  } else {
+    element.removeAttribute(attributeName);
+  }
+}
+
 class TableBody extends HTMLElement {
   static observedClassAttributes = {
     'data-stacked': stackedTableClass,
     'data-label-block': cellHeaderBlockClass,
   };
-  static observedAttributes = Object.keys(this.observedClassAttributes);
+  static observedAttributeCbs = {
+    'data-hover': (component, oldValue, newValue) => {
+      const shouldSet = shouldSetBooleanAttribute(newValue);
+      const rows = component.shadowRoot.querySelectorAll('cod-table-row');
+
+      rows.forEach((row) => {
+        setOrRemoveAttribute(row, 'data-hover', shouldSet);
+      });
+    },
+    'data-striped-row': (component, oldValue, newValue) => {
+      const shouldSet = shouldSetBooleanAttribute(newValue);
+      const rows = component.shadowRoot.querySelectorAll('cod-table-row');
+
+      rows.forEach((row, index) => {
+        setOrRemoveAttribute(
+          row,
+          'data-striped-row',
+          shouldSet && index % 2 === 0,
+        );
+      });
+    },
+    'data-striped-col': (component, oldValue, newValue) => {
+      const shouldSet = shouldSetBooleanAttribute(newValue);
+      const rows = component.shadowRoot.querySelectorAll('cod-table-row');
+
+      rows.forEach((row) => {
+        setOrRemoveAttribute(row, 'data-striped-col', shouldSet);
+      });
+    },
+    'data-vertical-align': (component, oldValue, newValue) => {
+      const shouldSet = shouldSetBooleanAttribute(newValue);
+      const rows = component.shadowRoot.querySelectorAll('cod-table-row');
+
+      rows.forEach((row) => {
+        setOrRemoveAttribute(row, 'data-vertical-align', shouldSet);
+      });
+    },
+    'data-scrollable': (component, oldValue, newValue) => {
+      const shouldSet = shouldSetBooleanAttribute(newValue);
+      const rows = component.shadowRoot.querySelectorAll('cod-table-row');
+
+      rows.forEach((row) => {
+        setOrRemoveAttribute(row, 'data-scrollable', shouldSet);
+      });
+    },
+  };
+  static observedAttributes = [
+    ...Object.keys(this.observedClassAttributes),
+    ...Object.keys(this.observedAttributeCbs),
+  ];
 
   constructor() {
     // Always call super first in constructor
@@ -94,6 +159,14 @@ class TableBody extends HTMLElement {
         () => {
           return this.shadowRoot.querySelectorAll('cod-table-row');
         },
+      );
+    }
+
+    if (name in TableBody.observedAttributeCbs) {
+      this.handleObservedAttribute(
+        oldValue,
+        newValue,
+        TableBody.observedAttributeCbs[name],
       );
     }
   }

--- a/src/experimental/components/atoms/TableCell/TableCell.js
+++ b/src/experimental/components/atoms/TableCell/TableCell.js
@@ -13,12 +13,48 @@ template.innerHTML = `
 <slot></slot>
 `;
 
+function shouldSetBooleanAttribute(value) {
+  return value === 'true';
+}
+
 class TableCell extends HTMLElement {
   static observedClassAttributes = {
     'data-stacked': stackedTableClass,
     'data-label-block': cellHeaderBlockClass,
   };
-  static observedAttributes = Object.keys(this.observedClassAttributes);
+  static observedAttributeCbs = {
+    'data-striped-row': (component, oldValue, newValue) => {
+      component.tableCell.classList.toggle(
+        'table-striped',
+        shouldSetBooleanAttribute(newValue),
+      );
+    },
+    'data-striped-col': (component, oldValue, newValue) => {
+      component.tableCell.classList.toggle(
+        'table-striped-columns',
+        shouldSetBooleanAttribute(newValue),
+      );
+    },
+    'data-scrollable': (component, oldValue, newValue) => {
+      component.tableCell.classList.toggle(
+        'table-scrollable',
+        shouldSetBooleanAttribute(newValue),
+      );
+    },
+    'data-vertical-align': (component, oldValue, newValue) => {
+      if (oldValue !== null) {
+        component.tableCell.classList.remove(oldValue);
+      }
+
+      if (newValue !== null) {
+        component.tableCell.classList.add(newValue);
+      }
+    },
+  };
+  static observedAttributes = [
+    ...Object.keys(this.observedClassAttributes),
+    ...Object.keys(this.observedAttributeCbs),
+  ];
 
   constructor() {
     // Always call super first in constructor
@@ -107,6 +143,14 @@ class TableCell extends HTMLElement {
         newValue,
         this.tableCell,
         TableCell.observedClassAttributes[name],
+      );
+    }
+
+    if (name in TableCell.observedAttributeCbs) {
+      this.handleObservedAttribute(
+        oldValue,
+        newValue,
+        TableCell.observedAttributeCbs[name],
       );
     }
   }

--- a/src/experimental/components/atoms/TableCellHeader/TableCellHeader.js
+++ b/src/experimental/components/atoms/TableCellHeader/TableCellHeader.js
@@ -13,12 +13,48 @@ template.innerHTML = `
 <slot></slot>
 `;
 
+function shouldSetBooleanAttribute(value) {
+  return value === 'true';
+}
+
 class TableCellHeader extends HTMLElement {
   static observedClassAttributes = {
     'data-stacked': stackedTableClass,
     'data-label-block': cellHeaderBlockClass,
   };
-  static observedAttributes = Object.keys(this.observedClassAttributes);
+  static observedAttributeCbs = {
+    'data-striped-row': (component, oldValue, newValue) => {
+      component.tableCellHeader.classList.toggle(
+        'table-striped',
+        shouldSetBooleanAttribute(newValue),
+      );
+    },
+    'data-striped-col': (component, oldValue, newValue) => {
+      component.tableCellHeader.classList.toggle(
+        'table-striped-columns',
+        shouldSetBooleanAttribute(newValue),
+      );
+    },
+    'data-scrollable': (component, oldValue, newValue) => {
+      component.tableCellHeader.classList.toggle(
+        'table-scrollable',
+        shouldSetBooleanAttribute(newValue),
+      );
+    },
+    'data-vertical-align': (component, oldValue, newValue) => {
+      if (oldValue !== null) {
+        component.tableCellHeader.classList.remove(oldValue);
+      }
+
+      if (newValue !== null) {
+        component.tableCellHeader.classList.add(newValue);
+      }
+    },
+  };
+  static observedAttributes = [
+    ...Object.keys(this.observedClassAttributes),
+    ...Object.keys(this.observedAttributeCbs),
+  ];
 
   constructor() {
     // Always call super first in constructor
@@ -95,6 +131,14 @@ class TableCellHeader extends HTMLElement {
         newValue,
         this.tableCellHeader,
         TableCellHeader.observedClassAttributes[name],
+      );
+    }
+
+    if (name in TableCellHeader.observedAttributeCbs) {
+      this.handleObservedAttribute(
+        oldValue,
+        newValue,
+        TableCellHeader.observedAttributeCbs[name],
       );
     }
   }

--- a/src/experimental/components/atoms/TableHeader/TableHeader.js
+++ b/src/experimental/components/atoms/TableHeader/TableHeader.js
@@ -15,12 +15,57 @@ template.innerHTML = `
 <slot></slot>
 `;
 
+function shouldSetBooleanAttribute(value) {
+  return value === 'true';
+}
+
+function setOrRemoveAttribute(element, attributeName, shouldSet) {
+  if (!element) {
+    return;
+  }
+
+  if (shouldSet) {
+    element.setAttribute(attributeName, 'true');
+  } else {
+    element.removeAttribute(attributeName);
+  }
+}
+
 class TableHeader extends HTMLElement {
   static observedClassAttributes = {
     'data-stacked': stackedTableClass,
     'data-label-block': cellHeaderBlockClass,
   };
-  static observedAttributes = Object.keys(this.observedClassAttributes);
+  static observedAttributeCbs = {
+    'data-striped-col': (component, oldValue, newValue) => {
+      const shouldSet = shouldSetBooleanAttribute(newValue);
+      const rows = component.shadowRoot.querySelectorAll('cod-table-row');
+
+      rows.forEach((row) => {
+        setOrRemoveAttribute(row, 'data-striped-col', shouldSet);
+      });
+    },
+    'data-vertical-align': (component, oldValue, newValue) => {
+      const shouldSet = shouldSetBooleanAttribute(newValue);
+      const rows = component.shadowRoot.querySelectorAll('cod-table-row');
+
+      rows.forEach((row) => {
+        setOrRemoveAttribute(row, 'data-vertical-align', shouldSet);
+      });
+    },
+    'data-scrollable': (component, oldValue, newValue) => {
+      const shouldSet = shouldSetBooleanAttribute(newValue);
+      const rows = component.shadowRoot.querySelectorAll('cod-table-row');
+
+      rows.forEach((row) => {
+        setOrRemoveAttribute(row, 'data-scrollable', shouldSet);
+      });
+    },
+  };
+  static observedAttributes = [
+    ...Object.keys(this.observedClassAttributes),
+    ...Object.keys(this.observedAttributeCbs),
+  ];
 
   constructor() {
     // Always call super first in constructor
@@ -81,6 +126,14 @@ class TableHeader extends HTMLElement {
         () => {
           return this.shadowRoot.querySelectorAll('cod-table-row');
         },
+      );
+    }
+
+    if (name in TableHeader.observedAttributeCbs) {
+      this.handleObservedAttribute(
+        oldValue,
+        newValue,
+        TableHeader.observedAttributeCbs[name],
       );
     }
   }

--- a/src/experimental/components/atoms/TableRow/TableRow.js
+++ b/src/experimental/components/atoms/TableRow/TableRow.js
@@ -16,12 +16,81 @@ template.innerHTML = `
 <slot></slot>
 `;
 
+function shouldSetBooleanAttribute(value) {
+  return value === 'true';
+}
+
+function setOrRemoveAttribute(element, attributeName, shouldSet) {
+  if (!element) {
+    return;
+  }
+
+  if (shouldSet) {
+    element.setAttribute(attributeName, 'true');
+  } else {
+    element.removeAttribute(attributeName);
+  }
+}
+
 class TableRow extends HTMLElement {
   static observedClassAttributes = {
     'data-stacked': stackedTableClass,
     'data-label-block': cellHeaderBlockClass,
   };
-  static observedAttributes = Object.keys(this.observedClassAttributes);
+  static observedAttributeCbs = {
+    'data-hover': (component, oldValue, newValue) => {
+      const shouldSet = shouldSetBooleanAttribute(newValue);
+      component.tableRow.classList.toggle('table-hover', shouldSet);
+    },
+    'data-striped-row': (component, oldValue, newValue) => {
+      const shouldSet = shouldSetBooleanAttribute(newValue);
+      const cells = component.shadowRoot.querySelectorAll(
+        'cod-table-cell, cod-table-cell-header',
+      );
+
+      cells.forEach((cell) => {
+        setOrRemoveAttribute(cell, 'data-striped-row', shouldSet);
+      });
+    },
+    'data-striped-col': (component, oldValue, newValue) => {
+      const shouldSet = shouldSetBooleanAttribute(newValue);
+      const cells = component.shadowRoot.querySelectorAll(
+        'cod-table-cell, cod-table-cell-header',
+      );
+
+      cells.forEach((cell, index) => {
+        setOrRemoveAttribute(
+          cell,
+          'data-striped-col',
+          shouldSet && index % 2 !== 0,
+        );
+      });
+    },
+    'data-vertical-align': (component, oldValue, newValue) => {
+      const shouldSet = shouldSetBooleanAttribute(newValue);
+      const cells = component.shadowRoot.querySelectorAll(
+        'cod-table-cell, cod-table-cell-header',
+      );
+
+      cells.forEach((cell) => {
+        setOrRemoveAttribute(cell, 'data-vertical-align', shouldSet);
+      });
+    },
+    'data-scrollable': (component, oldValue, newValue) => {
+      const shouldSet = shouldSetBooleanAttribute(newValue);
+      const cells = component.shadowRoot.querySelectorAll(
+        'cod-table-cell, cod-table-cell-header',
+      );
+
+      cells.forEach((cell) => {
+        setOrRemoveAttribute(cell, 'data-scrollable', shouldSet);
+      });
+    },
+  };
+  static observedAttributes = [
+    ...Object.keys(this.observedClassAttributes),
+    ...Object.keys(this.observedAttributeCbs),
+  ];
 
   constructor() {
     // Always call super first in constructor
@@ -102,6 +171,14 @@ class TableRow extends HTMLElement {
         () => {
           return this.shadowRoot.querySelectorAll('cod-table-cell');
         },
+      );
+    }
+
+    if (name in TableRow.observedAttributeCbs) {
+      this.handleObservedAttribute(
+        oldValue,
+        newValue,
+        TableRow.observedAttributeCbs[name],
       );
     }
   }

--- a/src/experimental/components/organisms/Table/Table.js
+++ b/src/experimental/components/organisms/Table/Table.js
@@ -11,6 +11,22 @@ template.innerHTML = `
 <slot></slot>
 `;
 
+function shouldSetBooleanAttribute(value) {
+  return value === 'true';
+}
+
+function setOrRemoveAttribute(element, attributeName, shouldSet) {
+  if (!element) {
+    return;
+  }
+
+  if (shouldSet) {
+    element.setAttribute(attributeName, 'true');
+  } else {
+    element.removeAttribute(attributeName);
+  }
+}
+
 class Table extends HTMLElement {
   static observedAttributeCbs = {
     'data-stacked': (component, oldValue, newValue) => {
@@ -36,6 +52,50 @@ class Table extends HTMLElement {
         tableHeader?.removeAttribute('data-label-block');
         tableBody?.removeAttribute('data-label-block');
       }
+    },
+    'data-hover': (component, oldValue, newValue) => {
+      const tableBody = component.shadowRoot.querySelector('cod-table-body');
+      setOrRemoveAttribute(
+        tableBody,
+        'data-hover',
+        shouldSetBooleanAttribute(newValue),
+      );
+    },
+    'data-striped-row': (component, oldValue, newValue) => {
+      const tableBody = component.shadowRoot.querySelector('cod-table-body');
+      setOrRemoveAttribute(
+        tableBody,
+        'data-striped-row',
+        shouldSetBooleanAttribute(newValue),
+      );
+    },
+    'data-striped-col': (component, oldValue, newValue) => {
+      const shouldSet = shouldSetBooleanAttribute(newValue);
+      const tableHeader =
+        component.shadowRoot.querySelector('cod-table-header');
+      const tableBody = component.shadowRoot.querySelector('cod-table-body');
+
+      setOrRemoveAttribute(tableHeader, 'data-striped-col', shouldSet);
+      setOrRemoveAttribute(tableBody, 'data-striped-col', shouldSet);
+    },
+    'data-vertical-align': (component, oldValue, newValue) => {
+      const shouldSet = shouldSetBooleanAttribute(newValue);
+      const tableHeader =
+        component.shadowRoot.querySelector('cod-table-header');
+      const tableBody = component.shadowRoot.querySelector('cod-table-body');
+
+      setOrRemoveAttribute(tableHeader, 'data-vertical-align', shouldSet);
+      setOrRemoveAttribute(tableBody, 'data-vertical-align', shouldSet);
+    },
+    'data-scrollable': (component, oldValue, newValue) => {
+      const shouldSet = shouldSetBooleanAttribute(newValue);
+      const tableHeader =
+        component.shadowRoot.querySelector('cod-table-header');
+      const tableBody = component.shadowRoot.querySelector('cod-table-body');
+
+      setOrRemoveAttribute(tableHeader, 'data-scrollable', shouldSet);
+      setOrRemoveAttribute(tableBody, 'data-scrollable', shouldSet);
+      component.tableContainer.className = shouldSet ? 'table-responsive' : '';
     },
   };
 


### PR DESCRIPTION
When custom elements are upgraded after the DOM is already parsed, cod-table can set data-striped attributes after nested table parts have already run slotchange. In that order, striping props stop at higher levels and do not reach rows and cells.\n\nThis adds observed-attribute callbacks across the table component chain so data-striped-row, data-striped-col, data-hover, data-scrollable, and data-vertical-align continue propagating when attributes are applied after upgrade.\n\nI ran:\n- npx eslint src/experimental/components/organisms/Table/Table.js src/experimental/components/atoms/TableBody/TableBody.js src/experimental/components/atoms/TableHeader/TableHeader.js src/experimental/components/atoms/TableRow/TableRow.js src/experimental/components/atoms/TableCell/TableCell.js src/experimental/components/atoms/TableCellHeader/TableCellHeader.js\n- npx prettier --check src/experimental/components/organisms/Table/Table.js src/experimental/components/atoms/TableBody/TableBody.js src/experimental/components/atoms/TableHeader/TableHeader.js src/experimental/components/atoms/TableRow/TableRow.js src/experimental/components/atoms/TableCell/TableCell.js src/experimental/components/atoms/TableCellHeader/TableCellHeader.js\n- yarn build:experimental\n\nI also attempted a Playwright runtime smoke check, but Chromium failed to launch in this environment with system error -88.\n\nFixes #188